### PR TITLE
Harden audit guarantees and CLI policy control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "loong-memory-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/README.md
+++ b/README.md
@@ -17,16 +17,20 @@ Phase 1 (Engine-first + CLI) is implemented:
   - deterministic hash embedding provider with multilingual tokenization
   - hybrid recall (FTS + cosine similarity)
   - policy enforcement (namespace + principal-scoped static rules)
+  - JSON-loadable static policy config support
   - vector persistence as compact BLOB with legacy JSON read compatibility
-  - audit sink contracts
+  - fallible, append-only audit sink contracts
 - `loong-memory-cli`
   - `init`, `put`, `get`, `recall`, `delete`, `audit`, `vector-health`, `vector-repair`
+  - global optional `--policy-file <path>` for CLI policy enforcement
+  - namespace-scoped, policy-gated `audit` reads with explicit principal
 
 ## Repository Layout
 
 - `crates/loong-memory-core`: core contracts and engine implementation.
 - `crates/loong-memory-cli`: command-line operational entrypoint.
 - `docs/architecture.md`: architecture and data model details.
+- `docs/examples/static-policy.example.json`: example JSON policy file for CLI enforcement.
 - `docs/research/onecontext-reverse-engineering.md`: onecontext implementation analysis and extracted design lessons.
 - `docs/research/phase1-evaluation-2026-03-08.md`: deep evaluation, optimization decisions, and verification results.
 - `docs/research/phase1-evaluation-round2-2026-03-08.md`: multilingual retrieval hardening and recall-bound enforcement.
@@ -36,6 +40,9 @@ Phase 1 (Engine-first + CLI) is implemented:
 - `docs/research/phase1-evaluation-round6-2026-03-08.md`: vector health diagnostics API/CLI and integrity observability tests.
 - `docs/research/phase1-evaluation-round7-2026-03-08.md`: vector repair API/CLI (`dry-run` + `apply`) and repair integrity tests.
 - `docs/research/phase1-evaluation-round8-2026-03-09.md`: maintenance command security hardening (policy/audit gated vector health/repair).
+- `docs/research/phase1-evaluation-round9-2026-03-14.md`: CLI policy control-plane and audit hardening evaluation.
+- `docs/plans/2026-03-14-cli-policy-control-plane-design.md`: design for CLI policy/audit control-plane hardening.
+- `docs/plans/2026-03-14-cli-policy-control-plane.md`: implementation plan for CLI policy/audit control-plane hardening.
 - `docs/roadmap.md`: phased expansion plan.
 
 ## Quick Start
@@ -47,8 +54,11 @@ cargo test --workspace
 # 2) initialize database
 cargo run -p loong-memory-cli -- init --db ./loong-memory.db
 
-# 3) write memory
-cargo run -p loong-memory-cli -- put \
+# 3) optionally enforce policy with a JSON config
+cp docs/examples/static-policy.example.json ./policy.json
+
+# 4) write memory
+cargo run -p loong-memory-cli -- --policy-file ./policy.json put \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --external-id profile \
@@ -56,31 +66,37 @@ cargo run -p loong-memory-cli -- put \
   --metadata '{"source":"seed"}' \
   --principal operator
 
-# 4) read memory
-cargo run -p loong-memory-cli -- get \
+# 5) read memory
+cargo run -p loong-memory-cli -- --policy-file ./policy.json get \
   --db ./loong-memory.db \
   --namespace agent-demo \
-  --external-id profile
+  --external-id profile \
+  --principal operator
 
-# 5) recall
-cargo run -p loong-memory-cli -- recall \
+# 6) recall
+cargo run -p loong-memory-cli -- --policy-file ./policy.json recall \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --query "rust sqlite" \
-  --limit 3
+  --limit 3 \
+  --principal operator
 
-# 6) audit trail
-cargo run -p loong-memory-cli -- audit --db ./loong-memory.db --limit 20
+# 7) audit trail (namespace + principal are required)
+cargo run -p loong-memory-cli -- --policy-file ./policy.json audit \
+  --db ./loong-memory.db \
+  --namespace agent-demo \
+  --limit 20 \
+  --principal operator
 
-# 7) vector health diagnostics
-cargo run -p loong-memory-cli -- vector-health \
+# 8) vector health diagnostics
+cargo run -p loong-memory-cli -- --policy-file ./policy.json vector-health \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --invalid-sample-limit 20 \
   --principal operator
 
-# 8) vector repair (dry-run by default, add --apply to write changes)
-cargo run -p loong-memory-cli -- vector-repair \
+# 9) vector repair (dry-run by default, add --apply to write changes)
+cargo run -p loong-memory-cli -- --policy-file ./policy.json vector-repair \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --issue-sample-limit 20 \
@@ -99,12 +115,26 @@ cargo test --workspace
 
 ## Security and Reliability Defaults
 
-- Namespace is required in every operation.
+- Namespace is required in every operation, including `audit`.
+- CLI defaults to `AllowAllPolicy` when `--policy-file` is omitted.
 - Policy is checked before store access.
+- Static JSON policy files can grant namespace-level and principal+namespace actions.
 - All actions emit auditable events (allow/deny + operation detail).
+- Audit reads are policy-gated and returned history excludes self-generated audit-read events.
+- Audit persistence surfaces write failures instead of silently dropping events.
+- SQLite audit persistence is append-only; duplicate audit event IDs fail instead of replacing history.
 - Store operations use transactions for consistency.
 - SQLite `busy_timeout` and WAL are enabled for concurrency resilience.
 - recall has an explicit upper bound (`max_recall_limit`) to prevent abusive scans.
+
+## Phase 1 Audit Semantics
+
+- Store writes and audit persistence are still decoupled in Phase 1.
+- A post-operation audit failure can therefore be returned after the store
+  mutation has already committed.
+- This release intentionally surfaces that failure instead of silently losing the
+  audit event; callers should inspect state before retrying after audit-related
+  errors.
 
 ## License
 

--- a/crates/loong-memory-cli/Cargo.toml
+++ b/crates/loong-memory-cli/Cargo.toml
@@ -18,3 +18,6 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 loong-memory-core = { path = "../loong-memory-core" }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/loong-memory-cli/src/main.rs
+++ b/crates/loong-memory-cli/src/main.rs
@@ -6,7 +6,7 @@ use clap::{ArgGroup, Parser, Subcommand};
 use loong_memory_core::{
     AllowAllPolicy, DeterministicHashEmbedder, EngineConfig, MemoryDeleteRequest, MemoryEngine,
     MemoryGetRequest, MemoryPutRequest, OperationContext, RecallRequest, ScoreWeights,
-    SqliteAuditLog, SqliteAuditSink, SqliteStore,
+    SqliteAuditSink, SqliteStore, StaticPolicy, StaticPolicyConfig,
 };
 use serde_json::{json, Value};
 
@@ -14,6 +14,8 @@ use serde_json::{json, Value};
 #[command(name = "loong-memory")]
 #[command(about = "Rust-native memory engine CLI", version)]
 struct Cli {
+    #[arg(long, global = true)]
+    policy_file: Option<PathBuf>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -113,9 +115,11 @@ struct AuditCommand {
     #[arg(long, default_value = "./loong-memory.db")]
     db: PathBuf,
     #[arg(long)]
-    namespace: Option<String>,
+    namespace: String,
     #[arg(long, default_value_t = 50)]
     limit: usize,
+    #[arg(long)]
+    principal: String,
 }
 
 #[derive(clap::Args, Debug)]
@@ -146,16 +150,17 @@ struct VectorRepairCommand {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    let policy_file = cli.policy_file.clone();
 
     match cli.command {
         Commands::Init(cmd) => handle_init(cmd),
-        Commands::Put(cmd) => handle_put(cmd),
-        Commands::Get(cmd) => handle_get(cmd),
-        Commands::Recall(cmd) => handle_recall(cmd),
-        Commands::Delete(cmd) => handle_delete(cmd),
-        Commands::Audit(cmd) => handle_audit(cmd),
-        Commands::VectorHealth(cmd) => handle_vector_health(cmd),
-        Commands::VectorRepair(cmd) => handle_vector_repair(cmd),
+        Commands::Put(cmd) => handle_put(cmd, policy_file.as_deref()),
+        Commands::Get(cmd) => handle_get(cmd, policy_file.as_deref()),
+        Commands::Recall(cmd) => handle_recall(cmd, policy_file.as_deref()),
+        Commands::Delete(cmd) => handle_delete(cmd, policy_file.as_deref()),
+        Commands::Audit(cmd) => handle_audit(cmd, policy_file.as_deref()),
+        Commands::VectorHealth(cmd) => handle_vector_health(cmd, policy_file.as_deref()),
+        Commands::VectorRepair(cmd) => handle_vector_repair(cmd, policy_file.as_deref()),
     }
 }
 
@@ -172,9 +177,9 @@ fn handle_init(cmd: InitCommand) -> Result<()> {
     }))
 }
 
-fn handle_put(cmd: PutCommand) -> Result<()> {
+fn handle_put(cmd: PutCommand, policy_file: Option<&Path>) -> Result<()> {
     let metadata = parse_metadata(&cmd.metadata)?;
-    let mut engine = open_engine(&cmd.db)?;
+    let mut engine = open_engine(&cmd.db, policy_file)?;
     let record = engine.put(
         &OperationContext::new(cmd.principal),
         &MemoryPutRequest {
@@ -187,8 +192,8 @@ fn handle_put(cmd: PutCommand) -> Result<()> {
     print_json(&record)
 }
 
-fn handle_get(cmd: GetCommand) -> Result<()> {
-    let engine = open_engine(&cmd.db)?;
+fn handle_get(cmd: GetCommand, policy_file: Option<&Path>) -> Result<()> {
+    let engine = open_engine(&cmd.db, policy_file)?;
     let record = engine.get(
         &OperationContext::new(cmd.principal),
         &MemoryGetRequest {
@@ -200,7 +205,7 @@ fn handle_get(cmd: GetCommand) -> Result<()> {
     print_json(&record)
 }
 
-fn handle_recall(cmd: RecallCommand) -> Result<()> {
+fn handle_recall(cmd: RecallCommand, policy_file: Option<&Path>) -> Result<()> {
     if cmd.limit == 0 {
         bail!("--limit must be greater than 0");
     }
@@ -209,7 +214,7 @@ fn handle_recall(cmd: RecallCommand) -> Result<()> {
         bail!("lexical/vector weights must sum to a positive value");
     }
 
-    let engine = open_engine(&cmd.db)?;
+    let engine = open_engine(&cmd.db, policy_file)?;
     let hits = engine.recall(
         &OperationContext::new(cmd.principal),
         &RecallRequest {
@@ -229,8 +234,8 @@ fn handle_recall(cmd: RecallCommand) -> Result<()> {
     }))
 }
 
-fn handle_delete(cmd: DeleteCommand) -> Result<()> {
-    let mut engine = open_engine(&cmd.db)?;
+fn handle_delete(cmd: DeleteCommand, policy_file: Option<&Path>) -> Result<()> {
+    let mut engine = open_engine(&cmd.db, policy_file)?;
     engine.delete(
         &OperationContext::new(cmd.principal),
         &MemoryDeleteRequest {
@@ -243,18 +248,21 @@ fn handle_delete(cmd: DeleteCommand) -> Result<()> {
     print_json(&json!({ "ok": true }))
 }
 
-fn handle_audit(cmd: AuditCommand) -> Result<()> {
-    let log = SqliteAuditLog::open(&cmd.db)
-        .with_context(|| format!("open sqlite audit log {}", cmd.db.display()))?;
-    let events = log.list(cmd.namespace.as_deref(), cmd.limit)?;
+fn handle_audit(cmd: AuditCommand, policy_file: Option<&Path>) -> Result<()> {
+    let engine = open_engine(&cmd.db, policy_file)?;
+    let events = engine.audit_events(
+        &OperationContext::new(cmd.principal),
+        &cmd.namespace,
+        cmd.limit,
+    )?;
     print_json(&json!({
         "count": events.len(),
         "events": events
     }))
 }
 
-fn handle_vector_health(cmd: VectorHealthCommand) -> Result<()> {
-    let engine = open_engine(&cmd.db)?;
+fn handle_vector_health(cmd: VectorHealthCommand, policy_file: Option<&Path>) -> Result<()> {
+    let engine = open_engine(&cmd.db, policy_file)?;
     let report = engine.vector_health(
         &OperationContext::new(cmd.principal),
         &cmd.namespace,
@@ -263,8 +271,8 @@ fn handle_vector_health(cmd: VectorHealthCommand) -> Result<()> {
     print_json(&report)
 }
 
-fn handle_vector_repair(cmd: VectorRepairCommand) -> Result<()> {
-    let mut engine = open_engine(&cmd.db)?;
+fn handle_vector_repair(cmd: VectorRepairCommand, policy_file: Option<&Path>) -> Result<()> {
+    let mut engine = open_engine(&cmd.db, policy_file)?;
     let report = engine.vector_repair(
         &OperationContext::new(cmd.principal),
         &cmd.namespace,
@@ -283,10 +291,10 @@ fn parse_metadata(metadata_raw: &str) -> Result<Value> {
     Ok(parsed)
 }
 
-fn open_engine(db_path: &Path) -> Result<MemoryEngine<SqliteStore>> {
+fn open_engine(db_path: &Path, policy_file: Option<&Path>) -> Result<MemoryEngine<SqliteStore>> {
     let store = SqliteStore::open(db_path)
         .with_context(|| format!("open sqlite store {}", db_path.display()))?;
-    let policy = Arc::new(AllowAllPolicy);
+    let policy = load_policy(policy_file)?;
     let embedder = Arc::new(DeterministicHashEmbedder::default());
     let audit = Arc::new(SqliteAuditSink::open(db_path)?);
 
@@ -297,6 +305,19 @@ fn open_engine(db_path: &Path) -> Result<MemoryEngine<SqliteStore>> {
         audit,
         EngineConfig::default(),
     ))
+}
+
+fn load_policy(policy_file: Option<&Path>) -> Result<Arc<dyn loong_memory_core::PolicyEngine>> {
+    match policy_file {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .with_context(|| format!("read policy file {}", path.display()))?;
+            let config: StaticPolicyConfig = serde_json::from_str(&raw)
+                .with_context(|| format!("parse policy file {}", path.display()))?;
+            Ok(Arc::new(StaticPolicy::from_config(config)))
+        }
+        None => Ok(Arc::new(AllowAllPolicy)),
+    }
 }
 
 fn print_json(value: &impl serde::Serialize) -> Result<()> {

--- a/crates/loong-memory-cli/tests/cli_policy_integration.rs
+++ b/crates/loong-memory-cli/tests/cli_policy_integration.rs
@@ -1,0 +1,179 @@
+use std::{fs, path::Path, process::Command};
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_loong-memory"))
+        .args(args)
+        .output()
+        .expect("run loong-memory cli")
+}
+
+fn write_policy(path: &Path, body: &str) {
+    fs::write(path, body).expect("write policy file");
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("parse stdout json")
+}
+
+#[test]
+fn audit_command_requires_principal() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let db = db_path.to_string_lossy().to_string();
+
+    let init = run_cli(&["init", "--db", &db]);
+    assert!(
+        init.status.success(),
+        "init stderr={}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let output = run_cli(&["audit", "--db", &db, "--namespace", "agent-demo"]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--principal"));
+}
+
+#[test]
+fn policy_file_allows_put_and_audit_for_operator() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let policy_path = dir.path().join("policy.json");
+    let db = db_path.to_string_lossy().to_string();
+    let policy = policy_path.to_string_lossy().to_string();
+
+    write_policy(
+        &policy_path,
+        r#"{
+  "principal_namespace_actions": [
+    {
+      "principal": "operator",
+      "namespace": "agent-demo",
+      "actions": ["put", "audit_read"]
+    }
+  ]
+}"#,
+    );
+
+    let init = run_cli(&["init", "--db", &db]);
+    assert!(
+        init.status.success(),
+        "init stderr={}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let put = run_cli(&[
+        "--policy-file",
+        &policy,
+        "put",
+        "--db",
+        &db,
+        "--namespace",
+        "agent-demo",
+        "--external-id",
+        "profile",
+        "--content",
+        "operator seeded memory",
+        "--principal",
+        "operator",
+    ]);
+    assert!(
+        put.status.success(),
+        "put stderr={}",
+        String::from_utf8_lossy(&put.stderr)
+    );
+
+    let audit = run_cli(&[
+        "--policy-file",
+        &policy,
+        "audit",
+        "--db",
+        &db,
+        "--namespace",
+        "agent-demo",
+        "--limit",
+        "20",
+        "--principal",
+        "operator",
+    ]);
+    assert!(
+        audit.status.success(),
+        "audit stderr={}",
+        String::from_utf8_lossy(&audit.stderr)
+    );
+
+    let payload = parse_stdout_json(&audit);
+    let events = payload["events"].as_array().expect("events array");
+    assert!(events.iter().any(|evt| evt["action"] == "Put"));
+    assert!(events.iter().any(|evt| evt["action"] == "put"));
+    assert!(!events.iter().any(|evt| evt["action"] == "AuditRead"));
+    assert!(!events.iter().any(|evt| evt["action"] == "audit_events"));
+}
+
+#[test]
+fn policy_file_denies_audit_without_audit_read_permission() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let policy_path = dir.path().join("policy.json");
+    let db = db_path.to_string_lossy().to_string();
+    let policy = policy_path.to_string_lossy().to_string();
+
+    write_policy(
+        &policy_path,
+        r#"{
+  "principal_namespace_actions": [
+    {
+      "principal": "operator",
+      "namespace": "agent-demo",
+      "actions": ["put"]
+    }
+  ]
+}"#,
+    );
+
+    let init = run_cli(&["init", "--db", &db]);
+    assert!(
+        init.status.success(),
+        "init stderr={}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let put = run_cli(&[
+        "--policy-file",
+        &policy,
+        "put",
+        "--db",
+        &db,
+        "--namespace",
+        "agent-demo",
+        "--external-id",
+        "profile",
+        "--content",
+        "operator seeded memory",
+        "--principal",
+        "operator",
+    ]);
+    assert!(
+        put.status.success(),
+        "put stderr={}",
+        String::from_utf8_lossy(&put.stderr)
+    );
+
+    let audit = run_cli(&[
+        "--policy-file",
+        &policy,
+        "audit",
+        "--db",
+        &db,
+        "--namespace",
+        "agent-demo",
+        "--limit",
+        "20",
+        "--principal",
+        "operator",
+    ]);
+    assert!(!audit.status.success());
+    assert!(String::from_utf8_lossy(&audit.stderr).contains("policy denied"));
+}

--- a/crates/loong-memory-core/src/audit.rs
+++ b/crates/loong-memory-core/src/audit.rs
@@ -61,7 +61,13 @@ impl FromStr for AuditEventKind {
 }
 
 pub trait AuditSink: Send + Sync {
-    fn record(&self, event: AuditEvent);
+    fn record(&self, event: AuditEvent) -> Result<(), LoongMemoryError>;
+
+    fn list(&self, _namespace: &str, _limit: usize) -> Result<Vec<AuditEvent>, LoongMemoryError> {
+        Err(LoongMemoryError::NotImplemented(
+            "audit event listing not implemented for this sink",
+        ))
+    }
 }
 
 #[derive(Debug, Default)]
@@ -76,10 +82,13 @@ impl InMemoryAuditSink {
 }
 
 impl AuditSink for InMemoryAuditSink {
-    fn record(&self, event: AuditEvent) {
-        if let Ok(mut guard) = self.events.lock() {
-            guard.push(event);
-        }
+    fn record(&self, event: AuditEvent) -> Result<(), LoongMemoryError> {
+        let mut guard = self
+            .events
+            .lock()
+            .map_err(|_| LoongMemoryError::Internal("in-memory audit lock poisoned".to_owned()))?;
+        guard.push(event);
+        Ok(())
     }
 }
 
@@ -134,28 +143,39 @@ impl SqliteAuditSink {
 }
 
 impl AuditSink for SqliteAuditSink {
-    fn record(&self, event: AuditEvent) {
-        let Ok(detail) = serde_json::to_string(&event.detail) else {
-            return;
-        };
-        if let Ok(conn) = self.conn.lock() {
-            let _ = conn.execute(
-                r#"
-                INSERT OR REPLACE INTO memory_audit (
-                    event_id, timestamp, principal, namespace, action, kind, detail
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-                "#,
-                params![
-                    event.event_id,
-                    event.timestamp.to_rfc3339(),
-                    event.principal,
-                    event.namespace,
-                    event.action,
-                    event.kind.as_str(),
-                    detail
-                ],
-            );
-        }
+    fn record(&self, event: AuditEvent) -> Result<(), LoongMemoryError> {
+        let detail = serde_json::to_string(&event.detail)
+            .map_err(|e| LoongMemoryError::Internal(format!("serialize audit detail json: {e}")))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| LoongMemoryError::Internal("sqlite audit lock poisoned".to_owned()))?;
+        conn.execute(
+            r#"
+            INSERT INTO memory_audit (
+                event_id, timestamp, principal, namespace, action, kind, detail
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![
+                event.event_id,
+                event.timestamp.to_rfc3339(),
+                event.principal,
+                event.namespace,
+                event.action,
+                event.kind.as_str(),
+                detail
+            ],
+        )
+        .map_err(|e| LoongMemoryError::Storage(format!("insert audit row: {e}")))?;
+        Ok(())
+    }
+
+    fn list(&self, namespace: &str, limit: usize) -> Result<Vec<AuditEvent>, LoongMemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| LoongMemoryError::Internal("sqlite audit lock poisoned".to_owned()))?;
+        list_audit_rows(&conn, Some(namespace), limit)
     }
 }
 
@@ -175,56 +195,7 @@ impl SqliteAuditLog {
         namespace: Option<&str>,
         limit: usize,
     ) -> Result<Vec<AuditEvent>, LoongMemoryError> {
-        let limit = limit.clamp(1, 2_000) as i64;
-        let mut out = Vec::new();
-
-        if let Some(ns) = namespace {
-            let mut stmt = self
-                .conn
-                .prepare(
-                    r#"
-                    SELECT event_id, timestamp, principal, namespace, action, kind, detail
-                    FROM memory_audit
-                    WHERE namespace = ?1
-                    ORDER BY timestamp DESC
-                    LIMIT ?2
-                    "#,
-                )
-                .map_err(|e| LoongMemoryError::Storage(format!("prepare audit query: {e}")))?;
-            let mut rows = stmt
-                .query(params![ns, limit])
-                .map_err(|e| LoongMemoryError::Storage(format!("query audit rows: {e}")))?;
-            while let Some(row) = rows
-                .next()
-                .map_err(|e| LoongMemoryError::Storage(format!("scan audit rows: {e}")))?
-            {
-                out.push(parse_audit_row(row)?);
-            }
-            return Ok(out);
-        }
-
-        let mut stmt = self
-            .conn
-            .prepare(
-                r#"
-                SELECT event_id, timestamp, principal, namespace, action, kind, detail
-                FROM memory_audit
-                ORDER BY timestamp DESC
-                LIMIT ?1
-                "#,
-            )
-            .map_err(|e| LoongMemoryError::Storage(format!("prepare audit query: {e}")))?;
-        let mut rows = stmt
-            .query(params![limit])
-            .map_err(|e| LoongMemoryError::Storage(format!("query audit rows: {e}")))?;
-        while let Some(row) = rows
-            .next()
-            .map_err(|e| LoongMemoryError::Storage(format!("scan audit rows: {e}")))?
-        {
-            out.push(parse_audit_row(row)?);
-        }
-
-        Ok(out)
+        list_audit_rows(&self.conn, namespace, limit)
     }
 
     pub fn get_by_id(&self, event_id: &str) -> Result<Option<AuditEvent>, LoongMemoryError> {
@@ -249,6 +220,61 @@ impl SqliteAuditLog {
         };
         Ok(Some(parse_audit_row(row)?))
     }
+}
+
+fn list_audit_rows(
+    conn: &Connection,
+    namespace: Option<&str>,
+    limit: usize,
+) -> Result<Vec<AuditEvent>, LoongMemoryError> {
+    let limit = limit.clamp(1, 2_000) as i64;
+    let mut out = Vec::new();
+
+    if let Some(ns) = namespace {
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT event_id, timestamp, principal, namespace, action, kind, detail
+                FROM memory_audit
+                WHERE namespace = ?1
+                ORDER BY timestamp DESC
+                LIMIT ?2
+                "#,
+            )
+            .map_err(|e| LoongMemoryError::Storage(format!("prepare audit query: {e}")))?;
+        let mut rows = stmt
+            .query(params![ns, limit])
+            .map_err(|e| LoongMemoryError::Storage(format!("query audit rows: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .map_err(|e| LoongMemoryError::Storage(format!("scan audit rows: {e}")))?
+        {
+            out.push(parse_audit_row(row)?);
+        }
+        return Ok(out);
+    }
+
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT event_id, timestamp, principal, namespace, action, kind, detail
+            FROM memory_audit
+            ORDER BY timestamp DESC
+            LIMIT ?1
+            "#,
+        )
+        .map_err(|e| LoongMemoryError::Storage(format!("prepare audit query: {e}")))?;
+    let mut rows = stmt
+        .query(params![limit])
+        .map_err(|e| LoongMemoryError::Storage(format!("query audit rows: {e}")))?;
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| LoongMemoryError::Storage(format!("scan audit rows: {e}")))?
+    {
+        out.push(parse_audit_row(row)?);
+    }
+
+    Ok(out)
 }
 
 fn parse_audit_row(row: &rusqlite::Row<'_>) -> Result<AuditEvent, LoongMemoryError> {

--- a/crates/loong-memory-core/src/engine.rs
+++ b/crates/loong-memory-core/src/engine.rs
@@ -91,7 +91,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
             "put",
             AuditEventKind::Write,
             json!({"id": out.id}),
-        );
+        )?;
         Ok(out)
     }
 
@@ -109,7 +109,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
             "get",
             AuditEventKind::Read,
             json!({"id": out.id}),
-        );
+        )?;
         Ok(out)
     }
 
@@ -127,7 +127,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
             "delete",
             AuditEventKind::Delete,
             json!({"ok": true}),
-        );
+        )?;
         Ok(())
     }
 
@@ -145,7 +145,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
             "recall",
             AuditEventKind::Recall,
             json!({"hits": out.len()}),
-        );
+        )?;
         Ok(out)
     }
 
@@ -169,7 +169,54 @@ impl<S: MemoryStore> MemoryEngine<S> {
                 "total_rows": out.total_rows,
                 "invalid_rows": out.invalid_rows
             }),
-        );
+        )?;
+        Ok(out)
+    }
+
+    pub fn audit_events(
+        &self,
+        ctx: &OperationContext,
+        namespace: &str,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, LoongMemoryError> {
+        self.validate_namespace(namespace)?;
+        let out = match self
+            .policy
+            .decide(&ctx.principal, namespace, Action::AuditRead)
+        {
+            PolicyDecision::Allow => self.audit.list(namespace, limit)?,
+            PolicyDecision::Deny(reason) => {
+                if let Err(err) = self.emit(
+                    ctx,
+                    namespace,
+                    "AuditRead",
+                    AuditEventKind::Denied,
+                    json!({"reason": reason}),
+                ) {
+                    return Err(LoongMemoryError::Internal(format!(
+                        "emit denied audit event failed: {err}; original denial: {reason}"
+                    )));
+                }
+                return Err(LoongMemoryError::PolicyDenied(reason));
+            }
+        };
+        self.emit(
+            ctx,
+            namespace,
+            "AuditRead",
+            AuditEventKind::Allowed,
+            json!({}),
+        )?;
+        self.emit(
+            ctx,
+            namespace,
+            "audit_events",
+            AuditEventKind::Read,
+            json!({
+                "count": out.len(),
+                "limit": limit
+            }),
+        )?;
         Ok(out)
     }
 
@@ -200,7 +247,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
                 "repaired_rows": out.repaired_rows,
                 "invalid_rows": out.invalid_rows
             }),
-        );
+        )?;
         Ok(out)
     }
 
@@ -218,17 +265,21 @@ impl<S: MemoryStore> MemoryEngine<S> {
                     &format!("{action:?}"),
                     AuditEventKind::Allowed,
                     json!({}),
-                );
+                )?;
                 Ok(())
             }
             PolicyDecision::Deny(reason) => {
-                self.emit(
+                if let Err(err) = self.emit(
                     ctx,
                     namespace,
                     &format!("{action:?}"),
                     AuditEventKind::Denied,
                     json!({"reason": reason}),
-                );
+                ) {
+                    return Err(LoongMemoryError::Internal(format!(
+                        "emit denied audit event failed: {err}; original denial: {reason}"
+                    )));
+                }
                 Err(LoongMemoryError::PolicyDenied(reason))
             }
         }
@@ -358,7 +409,7 @@ impl<S: MemoryStore> MemoryEngine<S> {
         action: &str,
         kind: AuditEventKind,
         detail: serde_json::Value,
-    ) {
+    ) -> Result<(), LoongMemoryError> {
         self.audit.record(AuditEvent {
             event_id: Uuid::new_v4().to_string(),
             timestamp: Utc::now(),
@@ -367,6 +418,6 @@ impl<S: MemoryStore> MemoryEngine<S> {
             action: action.to_owned(),
             kind,
             detail,
-        });
+        })
     }
 }

--- a/crates/loong-memory-core/src/lib.rs
+++ b/crates/loong-memory-core/src/lib.rs
@@ -19,7 +19,10 @@ pub use model::{
     MemoryDeleteRequest, MemoryGetRequest, MemoryPutRequest, MemoryRecord, RecallHit,
     RecallRequest, ScoreWeights,
 };
-pub use policy::{Action, AllowAllPolicy, PolicyDecision, PolicyEngine, StaticPolicy};
+pub use policy::{
+    Action, AllowAllPolicy, PolicyDecision, PolicyEngine, PrincipalNamespaceActionsConfig,
+    StaticPolicy, StaticPolicyConfig,
+};
 pub use store::{
     MemoryStore, SqliteStore, VectorHealthIssue, VectorHealthReport, VectorRepairIssue,
     VectorRepairReport,

--- a/crates/loong-memory-core/src/policy.rs
+++ b/crates/loong-memory-core/src/policy.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Action {
     Put,
     Get,
@@ -35,6 +38,21 @@ pub struct StaticPolicy {
     allow_principal_namespace: BTreeMap<(String, String), BTreeSet<Action>>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct StaticPolicyConfig {
+    #[serde(default)]
+    pub namespace_actions: BTreeMap<String, Vec<Action>>,
+    #[serde(default)]
+    pub principal_namespace_actions: Vec<PrincipalNamespaceActionsConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrincipalNamespaceActionsConfig {
+    pub principal: String,
+    pub namespace: String,
+    pub actions: Vec<Action>,
+}
+
 impl StaticPolicy {
     pub fn allow_namespace_actions(
         mut self,
@@ -59,6 +77,21 @@ impl StaticPolicy {
             .or_default()
             .extend(actions);
         self
+    }
+
+    pub fn from_config(config: StaticPolicyConfig) -> Self {
+        let mut policy = Self::default();
+        for (namespace, actions) in config.namespace_actions {
+            policy = policy.allow_namespace_actions(namespace, actions);
+        }
+        for entry in config.principal_namespace_actions {
+            policy = policy.allow_principal_namespace_actions(
+                entry.principal,
+                entry.namespace,
+                entry.actions,
+            );
+        }
+        policy
     }
 }
 

--- a/crates/loong-memory-core/tests/audit_sqlite_integration.rs
+++ b/crates/loong-memory-core/tests/audit_sqlite_integration.rs
@@ -26,7 +26,8 @@ fn sqlite_audit_sink_persists_and_log_reads_back() {
             action: "put".to_owned(),
             kind: AuditEventKind::Write,
             detail: json!({ "idx": idx }),
-        });
+        })
+        .expect("record event");
     }
 
     let log = SqliteAuditLog::open(&db_path).expect("open log");
@@ -52,6 +53,39 @@ fn sqlite_audit_sink_persists_and_log_reads_back() {
 }
 
 #[test]
+fn sqlite_audit_sink_rejects_duplicate_event_ids() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("audit.db");
+
+    let sink = SqliteAuditSink::open(&db_path).expect("open sink");
+    let event = AuditEvent {
+        event_id: "dup-1".to_owned(),
+        timestamp: Utc::now(),
+        principal: "tester".to_owned(),
+        namespace: "alpha".to_owned(),
+        action: "put".to_owned(),
+        kind: AuditEventKind::Write,
+        detail: json!({ "rev": 1 }),
+    };
+
+    sink.record(event.clone()).expect("insert original event");
+    let err = sink
+        .record(AuditEvent {
+            detail: json!({ "rev": 2 }),
+            ..event
+        })
+        .expect_err("duplicate event ids should fail");
+    assert!(matches!(err, LoongMemoryError::Storage(_)));
+
+    let log = SqliteAuditLog::open(&db_path).expect("open log");
+    let stored = log
+        .get_by_id("dup-1")
+        .expect("get by id")
+        .expect("event exists");
+    assert_eq!(stored.detail, json!({ "rev": 1 }));
+}
+
+#[test]
 fn sqlite_audit_log_limit_is_clamped() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("audit.db");
@@ -66,7 +100,8 @@ fn sqlite_audit_log_limit_is_clamped() {
             action: "op".to_owned(),
             kind: AuditEventKind::Read,
             detail: json!({}),
-        });
+        })
+        .expect("record event");
     }
 
     let log = SqliteAuditLog::open(&db_path).expect("open log");

--- a/crates/loong-memory-core/tests/engine_store_integration.rs
+++ b/crates/loong-memory-core/tests/engine_store_integration.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use loong_memory_core::{
     Action, AllowAllPolicy, AuditEventKind, AuditSink, DeterministicHashEmbedder,
     EmbeddingProvider, EngineConfig, InMemoryAuditSink, LoongMemoryError, MemoryDeleteRequest,
-    MemoryEngine, MemoryGetRequest, MemoryPutRequest, RecallRequest, ScoreWeights, SqliteStore,
-    StaticPolicy,
+    MemoryEngine, MemoryGetRequest, MemoryPutRequest, RecallRequest, ScoreWeights, SqliteAuditLog,
+    SqliteAuditSink, SqliteStore, StaticPolicy,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -32,6 +32,47 @@ fn build_engine(
     let embedder = Arc::new(DeterministicHashEmbedder::new(128));
     let audit_sink: Arc<dyn AuditSink> = audit;
     MemoryEngine::new(store, policy, embedder, audit_sink, EngineConfig::default())
+}
+
+fn build_sqlite_audit_engine(
+    db_path: &std::path::Path,
+    policy: Arc<dyn loong_memory_core::PolicyEngine>,
+) -> MemoryEngine<SqliteStore> {
+    let store = SqliteStore::open(db_path).expect("open sqlite");
+    let embedder = Arc::new(DeterministicHashEmbedder::new(128));
+    let audit_sink: Arc<dyn AuditSink> =
+        Arc::new(SqliteAuditSink::open(db_path).expect("open sqlite audit sink"));
+    MemoryEngine::new(store, policy, embedder, audit_sink, EngineConfig::default())
+}
+
+#[derive(Debug)]
+struct FailingAuditSink {
+    fail_on_call: usize,
+    calls: Mutex<usize>,
+}
+
+impl FailingAuditSink {
+    fn new(fail_on_call: usize) -> Self {
+        Self {
+            fail_on_call,
+            calls: Mutex::new(0),
+        }
+    }
+}
+
+impl AuditSink for FailingAuditSink {
+    fn record(&self, _event: loong_memory_core::AuditEvent) -> Result<(), LoongMemoryError> {
+        let mut calls = self.calls.lock().map_err(|_| {
+            LoongMemoryError::Internal("failing audit sink lock poisoned".to_owned())
+        })?;
+        *calls += 1;
+        if *calls == self.fail_on_call {
+            return Err(LoongMemoryError::Storage(
+                "forced audit sink failure".to_owned(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[test]
@@ -181,6 +222,49 @@ fn policy_deny_blocks_write_and_emits_denied_audit() {
             .any(|evt| matches!(evt.kind, AuditEventKind::Denied)),
         "expected at least one denied audit event"
     );
+}
+
+#[test]
+fn put_surfaces_post_write_audit_failure() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let policy = Arc::new(AllowAllPolicy);
+    let audit_sink: Arc<dyn AuditSink> = Arc::new(FailingAuditSink::new(2));
+    let store = SqliteStore::open(&db_path).expect("open sqlite");
+    let embedder = Arc::new(DeterministicHashEmbedder::new(128));
+    let mut engine =
+        MemoryEngine::new(store, policy, embedder, audit_sink, EngineConfig::default());
+    let ctx = loong_memory_core::OperationContext::new("tester");
+
+    let err = engine
+        .put(
+            &ctx,
+            &MemoryPutRequest {
+                namespace: "agent-a".to_owned(),
+                external_id: Some("profile".to_owned()),
+                content: "Alice likes rust systems programming".to_owned(),
+                metadata: json!({"source":"seed"}),
+            },
+        )
+        .expect_err("audit failure should be surfaced");
+    assert!(matches!(err, LoongMemoryError::Storage(_)));
+
+    let verify = build_engine(
+        &db_path,
+        Arc::new(AllowAllPolicy),
+        Arc::new(InMemoryAuditSink::default()),
+    );
+    let stored = verify
+        .get(
+            &ctx,
+            &MemoryGetRequest {
+                namespace: "agent-a".to_owned(),
+                id: None,
+                external_id: Some("profile".to_owned()),
+            },
+        )
+        .expect("write committed before audit failure surfaced");
+    assert_eq!(stored.content, "Alice likes rust systems programming");
 }
 
 #[test]
@@ -734,4 +818,102 @@ fn recall_skips_non_finite_vector_values() {
     assert_eq!(hits[0].record.id, created.id);
     assert_eq!(hits[0].vector_score, 0.0);
     assert!(hits[0].lexical_score > 0.0);
+}
+
+#[test]
+fn audit_read_without_reader_is_not_implemented() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let mut engine = build_engine(&db_path, allowed_policy_for("ops"), audit);
+    let ctx = loong_memory_core::OperationContext::new("ops-user");
+
+    engine
+        .put(
+            &ctx,
+            &MemoryPutRequest {
+                namespace: "ops".to_owned(),
+                external_id: Some("k1".to_owned()),
+                content: "seed audit row".to_owned(),
+                metadata: json!({}),
+            },
+        )
+        .expect("seed put");
+
+    let err = engine
+        .audit_events(&ctx, "ops", 10)
+        .expect_err("audit events require a configured reader");
+    assert!(matches!(err, LoongMemoryError::NotImplemented(_)));
+}
+
+#[test]
+fn audit_read_is_policy_gated_and_emits_denied_event() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let policy = Arc::new(StaticPolicy::default().allow_namespace_actions("ops", [Action::Put]));
+    let mut engine = build_sqlite_audit_engine(&db_path, policy);
+    let ctx = loong_memory_core::OperationContext::new("ops-user");
+
+    engine
+        .put(
+            &ctx,
+            &MemoryPutRequest {
+                namespace: "ops".to_owned(),
+                external_id: Some("k1".to_owned()),
+                content: "seed audit row".to_owned(),
+                metadata: json!({}),
+            },
+        )
+        .expect("seed put");
+
+    let err = engine
+        .audit_events(&ctx, "ops", 10)
+        .expect_err("audit read should be denied");
+    assert!(matches!(err, LoongMemoryError::PolicyDenied(_)));
+
+    let log = SqliteAuditLog::open(&db_path).expect("open sqlite audit log");
+    let events = log.list(Some("ops"), 20).expect("list audit log");
+    assert!(events
+        .iter()
+        .any(|evt| evt.action == "AuditRead" && matches!(evt.kind, AuditEventKind::Denied)));
+}
+
+#[test]
+fn audit_read_excludes_self_generated_audit_events_from_results() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("memory.db");
+    let policy = Arc::new(
+        StaticPolicy::default().allow_namespace_actions("ops", [Action::Put, Action::AuditRead]),
+    );
+    let mut engine = build_sqlite_audit_engine(&db_path, policy);
+    let ctx = loong_memory_core::OperationContext::new("ops-user");
+
+    engine
+        .put(
+            &ctx,
+            &MemoryPutRequest {
+                namespace: "ops".to_owned(),
+                external_id: Some("k1".to_owned()),
+                content: "seed audit row".to_owned(),
+                metadata: json!({}),
+            },
+        )
+        .expect("seed put");
+
+    let events = engine
+        .audit_events(&ctx, "ops", 20)
+        .expect("audit read should succeed");
+    assert!(!events.iter().any(|evt| evt.action == "AuditRead"));
+    assert!(!events.iter().any(|evt| evt.action == "audit_events"));
+    assert!(events.iter().any(|evt| evt.action == "Put"));
+    assert!(events.iter().any(|evt| evt.action == "put"));
+
+    let log = SqliteAuditLog::open(&db_path).expect("open sqlite audit log");
+    let persisted = log.list(Some("ops"), 20).expect("list audit log");
+    assert!(persisted
+        .iter()
+        .any(|evt| evt.action == "AuditRead" && matches!(evt.kind, AuditEventKind::Allowed)));
+    assert!(persisted
+        .iter()
+        .any(|evt| evt.action == "audit_events" && matches!(evt.kind, AuditEventKind::Read)));
 }

--- a/crates/loong-memory-core/tests/policy_static_tests.rs
+++ b/crates/loong-memory-core/tests/policy_static_tests.rs
@@ -1,4 +1,5 @@
-use loong_memory_core::{Action, PolicyDecision, PolicyEngine, StaticPolicy};
+use loong_memory_core::{Action, PolicyDecision, PolicyEngine, StaticPolicy, StaticPolicyConfig};
+use serde_json::json;
 
 #[test]
 fn static_policy_supports_principal_scoped_permissions() {
@@ -30,6 +31,42 @@ fn static_policy_is_deny_by_default() {
     let policy = StaticPolicy::default();
     assert!(matches!(
         policy.decide("anyone", "unknown", Action::Get),
+        PolicyDecision::Deny(_)
+    ));
+}
+
+#[test]
+fn static_policy_config_supports_snake_case_actions() {
+    let config: StaticPolicyConfig = serde_json::from_value(json!({
+        "namespace_actions": {
+            "shared": ["get", "recall"]
+        },
+        "principal_namespace_actions": [
+            {
+                "principal": "operator",
+                "namespace": "shared",
+                "actions": ["audit_read", "repair"]
+            }
+        ]
+    }))
+    .expect("parse static policy config");
+
+    let policy = StaticPolicy::from_config(config);
+
+    assert_eq!(
+        policy.decide("operator", "shared", Action::AuditRead),
+        PolicyDecision::Allow
+    );
+    assert_eq!(
+        policy.decide("operator", "shared", Action::Repair),
+        PolicyDecision::Allow
+    );
+    assert_eq!(
+        policy.decide("guest", "shared", Action::Get),
+        PolicyDecision::Allow
+    );
+    assert!(matches!(
+        policy.decide("guest", "shared", Action::Repair),
         PolicyDecision::Deny(_)
     ));
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Core contracts in `loong-memory-core`:
 - `MemoryStore`: persistence and retrieval backend.
 - `EmbeddingProvider`: text to vector interface.
 - `PolicyEngine`: authorization decision boundary.
-- `AuditSink`: immutable operation trail sink.
+- `AuditSink`: fallible audit write boundary with optional namespace-scoped audit listing.
 
 ### L1 Control Layer (`MemoryEngine`)
 
@@ -28,6 +28,12 @@ Core contracts in `loong-memory-core`:
 4. Emit audit events for allow/deny and operation result.
 
 This keeps control-plane decisions outside storage internals.
+
+Audit-read behavior is a special case:
+
+- `audit_events(ctx, namespace, limit)` first evaluates authorization,
+  reads the existing namespace audit history, then emits its own allow/read
+  audit events afterward so returned history is not polluted by the read itself.
 
 Validation guardrails at this layer include:
 
@@ -57,6 +63,12 @@ Store behavior:
   sampled invalid-row reasons for operator observability.
 - `vector_repair(namespace, sample_limit, apply)` provides repair planning and
   optional transactional apply for recoverable rows.
+
+Audit behavior:
+
+- SQLite audit persistence is append-only (`INSERT`, not replace/update).
+- duplicate audit event IDs fail explicitly.
+- namespace-scoped audit listing is available through the SQLite audit sink/log.
 
 ### L3 Retrieval Layer (Hybrid Recall)
 
@@ -95,11 +107,18 @@ For each query:
 ## 4. Security Model
 
 - Policy gate is enforced before every operation.
+- CLI can load a JSON `StaticPolicyConfig` via `--policy-file`; without it,
+  the CLI preserves current local-operator ergonomics with `AllowAllPolicy`.
 - Maintenance operations (`vector_health`, `vector_repair`) are executed through
   engine-level policy checks and audit events, not direct CLI store bypass.
+- Audit reads are namespace-scoped and require `Action::AuditRead`.
 - Namespace is mandatory at contract level and store query level.
 - Selector ambiguity (`id` + `external_id`) is rejected.
 - Audit captures deny and allow paths for traceability.
+- Audit write failures are surfaced instead of being silently ignored.
+- Because store and audit persistence are still decoupled in Phase 1, a
+  post-operation audit failure can be returned after the store mutation has
+  already committed.
 
 ## 5. Performance Model
 

--- a/docs/examples/static-policy.example.json
+++ b/docs/examples/static-policy.example.json
@@ -1,0 +1,12 @@
+{
+  "namespace_actions": {
+    "shared-readonly": ["get", "recall"]
+  },
+  "principal_namespace_actions": [
+    {
+      "principal": "operator",
+      "namespace": "agent-demo",
+      "actions": ["put", "get", "recall", "delete", "audit_read", "repair"]
+    }
+  ]
+}

--- a/docs/plans/2026-03-14-cli-policy-control-plane-design.md
+++ b/docs/plans/2026-03-14-cli-policy-control-plane-design.md
@@ -1,0 +1,279 @@
+# Audit Guarantees and CLI Control Plane Design
+
+Date: 2026-03-14
+Owner: chumyin
+
+## 1. Context
+
+`loong-memory` already exposes policy and audit abstractions in the core engine,
+and recent hardening work moved `vector-health` / `vector-repair` behind
+engine-level authorization and audit boundaries. The current CLI still has an
+important control-plane gap:
+
+- `audit` reads directly through `SqliteAuditLog`, bypassing engine-level policy
+  flow.
+- `audit` allows omitting `namespace`, which conflicts with the documented
+  security default that namespace is required in every operation.
+- the CLI always uses `AllowAllPolicy`, so the repository claims
+  principal-scoped/static policy support in practice only at the library layer,
+  not at the default operator entrypoint.
+- audit persistence is too important to remain a silent best-effort concern.
+
+Evidence:
+
+- `crates/loong-memory-cli/src/main.rs` routes `audit` directly to
+  `SqliteAuditLog::list(...)`.
+- `README.md` states "Policy is checked before store access" and "Namespace is
+  required in every operation".
+- `docs/architecture.md` states policy is enforced before every operation.
+
+## 2. Problem Statement
+
+The repository currently has a documented security model that is stronger than
+the CLI control plane it actually ships. That makes the project look more
+complete than it is and weakens the credibility of its policy boundary story.
+
+This is not just a docs issue. The CLI is the operator surface for Phase 1, so
+when it bypasses or weakens the control plane, the repository's real delivery
+quality is lower than the architecture documents imply.
+
+## 3. Goals
+
+1. Make CLI policy enforcement operationally usable, not just theoretically
+   available in `loong-memory-core`.
+2. Route audit reads through the same authorization boundary as other protected
+   operations.
+3. Align CLI behavior with the documented namespace and audit model.
+4. Surface audit persistence failures instead of silently dropping them.
+5. Preserve current default ergonomics when no policy file is configured.
+6. Add regression tests that prove the new control-plane behavior end to end.
+
+## 4. Non-Goals
+
+- dynamic RBAC / ABAC policy engines
+- multi-namespace or global audit queries
+- transport-layer authn/authz for a future daemon
+- changing the storage format or retrieval algorithms
+- fully atomic store+audit commit semantics in Phase 1
+
+## 5. Approaches Considered
+
+### Approach A: Narrow `audit` Command Hardening Only
+
+Change only `audit` so it requires `namespace` and checks policy before reading.
+
+Pros:
+
+- smallest code change
+- closes the direct audit-read bypass
+
+Cons:
+
+- still leaves the CLI stuck on `AllowAllPolicy`
+- does not make principal-scoped policy usable in real operator flows
+- keeps the gap between architecture claims and CLI reality only partially fixed
+
+### Approach B: Delivery-Grade CLI Policy Control Plane + Audit Hardening
+
+Add CLI-loadable static policy config, move audit reads behind an engine-level
+audit read boundary, and harden audit persistence semantics.
+
+Pros:
+
+- closes the bypass
+- makes static policy usable from the shipped binary
+- aligns README, architecture, and operator behavior
+- creates a reusable policy config path for future daemon/SDK layers
+- makes audit loss/overwrite behavior explicit instead of silent
+
+Cons:
+
+- touches both core and CLI contracts
+- requires new regression coverage and docs updates
+
+### Approach C: Focus on Vector Integrity Preventive Hardening
+
+Add stronger embedder/vector validation on write/query paths.
+
+Pros:
+
+- strong internal robustness value
+
+Cons:
+
+- does not address the most visible control-plane inconsistency
+- lower delivery ROI for this phase than making the CLI security model real
+
+## 6. Chosen Approach
+
+Approach B.
+
+This round should deepen the project where it most affects operator trust:
+policy usability, audit persistence honesty, and audit-read governance at the
+CLI boundary.
+
+## 7. Proposed Design
+
+## 7.1 Harden the Audit Contract
+
+The audit contract should be fallible and append-only:
+
+- audit write failures are surfaced
+- SQLite audit rows reject duplicate `event_id` values
+- namespace-scoped audit listing remains available for engine-level reads
+
+Residual semantics:
+
+- because store and audit are still separate in Phase 1, a post-operation audit
+  failure can be returned after the store mutation has already committed
+
+## 7.2 Extend the Audit Contract with Optional Read Support
+
+Extend `AuditSink` in `loong-memory-core` so it can optionally expose
+namespace-scoped audit listing:
+
+- purpose: list audit events for a single namespace with bounded limits
+- default behavior: explicit `NotImplemented`
+- SQLite implementation: `SqliteAuditSink`
+
+This keeps the existing engine construction path intact while allowing audit
+read behavior only for sinks that actually support it.
+
+## 7.3 Extend `MemoryEngine` with Audit Read Operation
+
+Add an engine method for namespace-scoped audit reads:
+
+- validates `namespace`
+- validates/bounds `limit`
+- enforces `Action::AuditRead`
+- lists namespace audit events through the configured audit sink
+- emits audit events summarizing the operation
+
+Important implementation detail:
+
+- The returned audit history must not be polluted by the audit command's own
+  authorization event. To preserve useful results, the audit read operation
+  should query the log first and emit its allow/read events only after the read
+  result has been collected.
+
+This requires a small refactor away from using the generic `enforce()` helper
+for audit reads, because the allow event must be emitted only after the history
+has been collected.
+
+## 7.4 Make Static Policy Config Loadable from the CLI
+
+Add a CLI-wide optional `--policy-file <path>` flag.
+
+Behavior:
+
+- when absent: preserve current `AllowAllPolicy` default
+- when present: load JSON config into `StaticPolicy`
+- malformed config: fail fast with path-aware error text
+
+Proposed JSON schema:
+
+```json
+{
+  "namespace_actions": {
+    "shared-readonly": ["get", "recall"]
+  },
+  "principal_namespace_actions": [
+    {
+      "principal": "operator",
+      "namespace": "agent-demo",
+      "actions": ["put", "get", "recall", "delete", "audit_read", "repair"]
+    }
+  ]
+}
+```
+
+Why JSON:
+
+- already supported by existing dependencies
+- easy to validate and document
+- avoids adding a new parser dependency for this phase
+
+## 7.5 Tighten CLI Audit Semantics
+
+Change `loong-memory audit` to require:
+
+- `--namespace`
+- `--principal`
+
+And route it through `MemoryEngine`, not direct `SqliteAuditLog`.
+
+This makes audit inspection consistent with the repository's existing security
+model:
+
+- namespace-scoped
+- policy-gated
+- auditable
+
+## 7.6 Documentation and Example Artifacts
+
+Update:
+
+- `README.md`
+- `docs/architecture.md`
+- a new example policy file under `docs/examples/`
+- a research note for this round under `docs/research/`
+
+The README should explicitly state:
+
+- CLI defaults to allow-all unless `--policy-file` is supplied
+- namespace-scoped audit reads now require `--namespace` and `--principal`
+- example policy grants for operator maintenance flows
+
+## 8. Testing Strategy
+
+### Core Tests
+
+- policy config parsing into `StaticPolicy`
+- engine audit read is denied without `Action::AuditRead`
+- engine audit read succeeds with `Action::AuditRead`
+- audit read without configured reader returns `NotImplemented`
+- returned audit history does not contain self-generated audit-read events
+
+### CLI Tests
+
+- `audit` requires `--namespace`
+- policy file can authorize `put` + `audit`
+- policy file denial prevents `audit`
+
+### Verification Gates
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+## 9. Risks and Mitigations
+
+Risk: audit-read self-pollution makes small-limit results unusable.
+
+Mitigation:
+
+- list first, emit audit events after collecting results
+- add a regression test for this exact behavior
+
+Risk: CLI policy file format becomes too clever for Phase 1.
+
+Mitigation:
+
+- JSON only
+- no inheritance, wildcards, or condition expressions
+- direct mapping to existing `StaticPolicy`
+
+Risk: engine constructor churn spreads unnecessary change.
+
+Mitigation:
+
+- keep existing constructor path viable
+- attach audit-read capability through the existing audit sink abstraction
+
+## 10. Success Criteria
+
+- a user can enforce namespace/principal-scoped permissions from the CLI with a
+  checked-in JSON policy file
+- `audit` no longer bypasses the engine control plane
+- README and architecture docs match shipped CLI behavior
+- regression tests prove both allow and deny behavior

--- a/docs/plans/2026-03-14-cli-policy-control-plane.md
+++ b/docs/plans/2026-03-14-cli-policy-control-plane.md
@@ -1,0 +1,238 @@
+# Audit Guarantees and CLI Control Plane Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Harden audit persistence semantics and make `loong-memory-cli` a real policy-aware operator surface by adding static policy-file loading and moving audit reads behind engine-level authorization and audit boundaries.
+
+**Architecture:** Make the audit contract fallible and append-only, preserve namespace-scoped audit reads through `MemoryEngine`, then wire the CLI to load a JSON `StaticPolicy` and route `audit` through the same governed path as other protected operations. Keep backward compatibility by defaulting to `AllowAllPolicy` when no policy file is supplied.
+
+**Tech Stack:** Rust workspace, `clap`, `serde`, `serde_json`, `rusqlite`, `tempfile`, `std::process::Command`
+
+---
+
+### Task 1: Add optional read-side audit support in core
+
+**Files:**
+- Modify: `crates/loong-memory-core/src/audit.rs`
+- Modify: `crates/loong-memory-core/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+Add/prepare a core integration test that tries to call engine audit-read without a supporting audit sink and expects `NotImplemented`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memory-core audit_read_without_reader_is_not_implemented -- --exact`
+Expected: FAIL because the engine method/contract does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- extend `AuditSink` with namespace-scoped `list(...)`
+- keep default behavior as `NotImplemented`
+- implement list support for `SqliteAuditSink`
+- export the updated contract from `lib.rs`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memory-core audit_read_without_reader_is_not_implemented -- --exact`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memory-core/src/audit.rs crates/loong-memory-core/src/lib.rs
+git commit -m "feat(core): add audit log reader contract"
+```
+
+### Task 2: Refactor engine authorization flow and add audit-read operation
+
+**Files:**
+- Modify: `crates/loong-memory-core/src/engine.rs`
+- Modify: `crates/loong-memory-core/tests/engine_store_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add focused tests for:
+
+- audit read denied without `Action::AuditRead`
+- audit read allowed with `Action::AuditRead`
+- audit read result excludes self-generated audit-read events
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memory-core audit_read -- --nocapture`
+Expected: FAIL because engine audit-read does not exist or behavior is wrong.
+
+**Step 3: Write minimal implementation**
+
+- split authorization decision from allow-event emission
+- keep deny events immediate
+- add engine audit-read method using the attached audit sink
+- emit allow/read events after collecting the history
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memory-core audit_read -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memory-core/src/engine.rs crates/loong-memory-core/tests/engine_store_integration.rs
+git commit -m "feat(core): gate audit reads through memory engine"
+```
+
+### Task 3: Add JSON static policy config support
+
+**Files:**
+- Modify: `crates/loong-memory-core/src/policy.rs`
+- Modify: `crates/loong-memory-core/src/lib.rs`
+- Test: `crates/loong-memory-core/tests/policy_static_tests.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that deserialize JSON policy config with:
+
+- namespace-level actions
+- principal+namespace actions
+- `audit_read` and `repair` action names
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memory-core static_policy_ -- --nocapture`
+Expected: FAIL because serde config support is missing.
+
+**Step 3: Write minimal implementation**
+
+- derive serde support for `Action`
+- define a config shape that maps directly to `StaticPolicy`
+- add constructor/helper that builds `StaticPolicy` from config
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memory-core static_policy_ -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memory-core/src/policy.rs crates/loong-memory-core/src/lib.rs crates/loong-memory-core/tests/policy_static_tests.rs
+git commit -m "feat(policy): support static policy config files"
+```
+
+### Task 4: Wire CLI to load policy files and route audit through engine
+
+**Files:**
+- Modify: `crates/loong-memory-cli/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Create CLI integration tests covering:
+
+- `audit` requires `--namespace`
+- `audit` requires `--principal`
+- `--policy-file` allows `put` and `audit` for an operator principal
+- `--policy-file` denies `audit` when `audit_read` is missing
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memory-cli --test cli_policy_integration -- --nocapture`
+Expected: FAIL because the CLI has no policy-file support and `audit` still bypasses engine.
+
+**Step 3: Write minimal implementation**
+
+- add a global `--policy-file` CLI flag
+- load JSON policy file into `StaticPolicy`
+- require `namespace` and `principal` on `audit`
+- route `audit` through the new engine method
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memory-cli --test cli_policy_integration -- --nocapture`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memory-cli/src/main.rs crates/loong-memory-cli/tests/cli_policy_integration.rs
+git commit -m "feat(cli): add policy-aware audit control plane"
+```
+
+### Task 5: Publish docs and operator examples
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Create: `docs/examples/static-policy.example.json`
+- Create: `docs/research/phase1-evaluation-round9-2026-03-14.md`
+
+**Step 1: Write the failing test**
+
+Use command-output verification instead of unit tests:
+
+- `cargo run -p loong-memory-cli -- audit --help`
+- `cargo run -p loong-memory-cli -- --help`
+
+Check that help text and README examples are now aligned.
+
+**Step 2: Run command to verify old behavior**
+
+Run: `cargo run -p loong-memory-cli -- audit --help`
+Expected: output still shows optional namespace / no policy-file guidance before the docs update.
+
+**Step 3: Write minimal implementation**
+
+- update quick-start and security sections
+- add operator-facing example policy file
+- record the round9 rationale and verification evidence
+
+**Step 4: Run command to verify it passes**
+
+Run: `cargo run -p loong-memory-cli -- audit --help`
+Expected: help matches required namespace/principal semantics and README docs.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/architecture.md docs/examples/static-policy.example.json docs/research/phase1-evaluation-round9-2026-03-14.md
+git commit -m "docs: document cli policy control plane"
+```
+
+### Task 6: Run full workspace verification
+
+**Files:**
+- Modify only if verification reveals issues
+
+**Step 1: Run formatting**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 2: Run lint**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: PASS
+
+**Step 3: Run tests**
+
+Run: `cargo test --workspace`
+Expected: PASS
+
+**Step 4: Inspect git isolation**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only task-scoped changes are present.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs crates
+git commit -m "feat: harden cli policy control plane"
+```

--- a/docs/research/phase1-evaluation-round9-2026-03-14.md
+++ b/docs/research/phase1-evaluation-round9-2026-03-14.md
@@ -1,0 +1,118 @@
+# Phase 1 Deep Evaluation Round 9
+
+Date: 2026-03-14
+Scope: CLI policy control plane and audit hardening
+
+## 1. Objective
+
+Round8 moved maintenance commands behind the engine policy boundary. A follow-up
+review showed that the operator-facing CLI still had a material control-plane
+gap:
+
+- `audit` read directly through `SqliteAuditLog`, bypassing engine policy flow
+- CLI always used `AllowAllPolicy`, so principal-scoped policy support was not
+  operationally usable from the shipped binary
+- audit persistence remained fail-open and SQLite audit storage was not
+  append-only
+
+This round closes those gaps and aligns the shipped CLI with the repository's
+documented security model.
+
+## 2. Findings
+
+Pre-change risk:
+
+- audit history could be read without engine-level authorization semantics
+- audit event writes could fail silently
+- duplicate audit event IDs could overwrite history
+- CLI policy support existed in the core model but not in the operator surface
+
+## 3. Implementation
+
+## 3.1 Audit Contract Hardening
+
+- `AuditSink::record` is now fallible and returns `Result<(), LoongMemoryError>`
+- SQLite audit persistence now uses strict `INSERT`
+- duplicate audit event IDs surface as storage errors instead of replacing rows
+
+## 3.2 Engine-Level Audit Read Path
+
+Added `MemoryEngine::audit_events(ctx, namespace, limit)`:
+
+- validates namespace
+- evaluates `Action::AuditRead`
+- reads namespace-scoped audit history from the configured audit sink
+- emits allow/read audit events after collecting the result
+
+This preserves useful history output by excluding self-generated `audit` events
+from the returned payload.
+
+## 3.3 Static Policy Config Support
+
+Added JSON-deserializable static policy config in `loong-memory-core`:
+
+- `StaticPolicyConfig`
+- `PrincipalNamespaceActionsConfig`
+- `StaticPolicy::from_config(...)`
+
+`Action` now deserializes using snake_case names such as `audit_read`.
+
+## 3.4 CLI Policy Control Plane
+
+`loong-memory-cli` now supports:
+
+- global optional `--policy-file <path>`
+- JSON static policy loading into `StaticPolicy`
+- namespace-scoped, principal-required `audit`
+- engine-routed audit reads instead of direct `SqliteAuditLog` bypass
+
+CLI behavior is intentionally preserved for local development when no
+`--policy-file` is supplied: policy defaults to `AllowAllPolicy`.
+
+## 4. Verification
+
+Focused tests added/updated:
+
+- `audit_sqlite_integration::sqlite_audit_sink_rejects_duplicate_event_ids`
+- `engine_store_integration::put_surfaces_post_write_audit_failure`
+- `engine_store_integration::audit_read_without_reader_is_not_implemented`
+- `engine_store_integration::audit_read_is_policy_gated_and_emits_denied_event`
+- `engine_store_integration::audit_read_excludes_self_generated_audit_events_from_results`
+- `policy_static_tests::static_policy_config_supports_snake_case_actions`
+- `cli_policy_integration::audit_command_requires_principal`
+- `cli_policy_integration::policy_file_allows_put_and_audit_for_operator`
+- `cli_policy_integration::policy_file_denies_audit_without_audit_read_permission`
+
+Planned full quality gates for final verification:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+## 5. Impact
+
+Security:
+
+- closes the audit-read CLI bypass path
+- makes principal-scoped static policy enforceable from the shipped binary
+
+Auditability:
+
+- audit writes are no longer silently best-effort
+- SQLite audit history is append-only
+- `audit` output remains useful because self-generated read events are excluded
+
+Delivery quality:
+
+- README, architecture, example policy, and CLI behavior now describe the same
+  control-plane model
+
+## 6. Residual Risk
+
+- CLI still defaults to `AllowAllPolicy` when no `--policy-file` is supplied;
+  this is intentional for local ergonomics but must be understood by operators.
+- audit persistence failures can now surface after a store mutation has already
+  committed; callers should inspect state before retrying after audit-related
+  errors.
+- static policy remains a simple allow-list model; richer policy engines remain
+  future work.


### PR DESCRIPTION
## Summary

This PR hardens `loong-memory`'s audit guarantees and makes the CLI control plane meaningfully policy-aware.

Key changes:

- make audit persistence fallible instead of silently best-effort
- make SQLite audit writes append-only by rejecting duplicate `event_id` rows
- add engine-level namespace-scoped `audit_events` with `Action::AuditRead` enforcement
- avoid polluting returned audit history with the current audit-read operation's own events
- add JSON static policy config support (`StaticPolicyConfig` + `StaticPolicy::from_config`)
- add CLI-wide `--policy-file` support and route `audit` through `MemoryEngine`
- require explicit `--namespace` and `--principal` for `loong-memory audit`
- add CLI integration tests, example policy docs, and round9 research notes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -p loong-memory-cli -- audit --help`

## Notes

- CLI behavior is preserved for local development when `--policy-file` is omitted: it still defaults to `AllowAllPolicy`.
- Audit persistence errors are now surfaced. Because audit and store writes are still separate in Phase 1, callers should inspect state before retrying after audit-related write failures.

Closes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added `--policy-file` option to enforce security policies via JSON configuration files.
  - Audit operations now require `--principal` flag and enforce policy-based access control.
  - Audit reads are now namespace- and principal-scoped with policy gating.

* **Bug Fixes**
  - Audit operation failures now surface as errors instead of being silently ignored.
  - Audit records use append-only persistence; duplicate IDs are explicitly rejected.

* **Documentation**
  - Added policy configuration examples and Quick Start guidance for policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->