### PR TITLE
feat: add loong-memoryd HTTP service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -98,10 +98,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -125,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +209,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -236,6 +312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -282,6 +369,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,8 +427,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -310,7 +455,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -361,6 +506,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,10 +637,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -400,6 +754,22 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -460,6 +830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,7 +862,7 @@ dependencies = [
  "approx",
  "chrono",
  "hex",
- "rand",
+ "rand 0.8.5",
  "rusqlite",
  "serde",
  "serde_json",
@@ -498,6 +874,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "loong-memoryd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "loong-memory-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,10 +906,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -518,7 +940,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -543,16 +965,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -583,6 +1026,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +1088,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -604,8 +1108,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -615,7 +1129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -625,6 +1149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -645,6 +1178,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +1245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,7 +1260,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -677,6 +1303,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
@@ -728,6 +1360,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,16 +1409,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -777,6 +1470,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +1499,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -819,11 +1532,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -880,6 +1702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +1724,30 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -934,6 +1786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1829,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1037,6 +1912,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,12 +2001,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1193,6 +2244,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +2286,66 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/loong-memory-core",
   "crates/loong-memory-cli",
+  "crates/loong-memoryd",
 ]
 resolver = "2"
 
@@ -28,3 +29,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.8"
 tempfile = "3"
 approx = "0.5"
+axum = "0.8"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "sync"] }
+tower = { version = "0.5", features = ["util"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ It is designed around four non-negotiable goals:
 
 ## Current Status
 
-Phase 1 (Engine-first + CLI) is implemented:
+Phase 1 (Engine-first + CLI) is implemented, and Phase 2 has started with a
+minimal daemon surface:
 
 - `loong-memory-core`
   - transactional SQLite memory store
@@ -24,11 +25,21 @@ Phase 1 (Engine-first + CLI) is implemented:
   - `init`, `put`, `get`, `recall`, `delete`, `audit`, `vector-health`, `vector-repair`
   - global optional `--policy-file <path>` for CLI policy enforcement
   - namespace-scoped, policy-gated `audit` reads with explicit principal
+- `loong-memoryd`
+  - standalone HTTP JSON daemon
+  - `GET /healthz`
+  - `POST /v1/memories`
+  - `POST /v1/memories/get`
+  - `POST /v1/recall`
+  - `POST /v1/audit`
+  - per-request `MemoryEngine` construction on blocking workers
+  - transport-level principal envelope via `x-loong-principal`
 
 ## Repository Layout
 
 - `crates/loong-memory-core`: core contracts and engine implementation.
 - `crates/loong-memory-cli`: command-line operational entrypoint.
+- `crates/loong-memoryd`: standalone Phase 2 HTTP daemon.
 - `docs/architecture.md`: architecture and data model details.
 - `docs/examples/static-policy.example.json`: example JSON policy file for CLI enforcement.
 - `docs/research/onecontext-reverse-engineering.md`: onecontext implementation analysis and extracted design lessons.
@@ -41,8 +52,11 @@ Phase 1 (Engine-first + CLI) is implemented:
 - `docs/research/phase1-evaluation-round7-2026-03-08.md`: vector repair API/CLI (`dry-run` + `apply`) and repair integrity tests.
 - `docs/research/phase1-evaluation-round8-2026-03-09.md`: maintenance command security hardening (policy/audit gated vector health/repair).
 - `docs/research/phase1-evaluation-round9-2026-03-14.md`: CLI policy control-plane and audit hardening evaluation.
+- `docs/research/phase2-service-evaluation-2026-03-15.md`: minimal daemon transport evaluation and verification notes.
 - `docs/plans/2026-03-14-cli-policy-control-plane-design.md`: design for CLI policy/audit control-plane hardening.
 - `docs/plans/2026-03-14-cli-policy-control-plane.md`: implementation plan for CLI policy/audit control-plane hardening.
+- `docs/plans/2026-03-15-loong-memoryd-http-design.md`: design for the minimal daemon HTTP surface.
+- `docs/plans/2026-03-15-loong-memoryd-http.md`: implementation plan for the minimal daemon HTTP surface.
 - `docs/roadmap.md`: phased expansion plan.
 
 ## Quick Start
@@ -101,6 +115,45 @@ cargo run -p loong-memory-cli -- --policy-file ./policy.json vector-repair \
   --namespace agent-demo \
   --issue-sample-limit 20 \
   --principal operator
+
+# 10) start the daemon
+cargo run -p loong-memoryd -- \
+  --db ./loong-memory.db \
+  --listen-addr 127.0.0.1:3000 \
+  --policy-file ./policy.json
+
+# 11) health check (no principal required)
+curl http://127.0.0.1:3000/healthz
+
+# 12) daemon write
+curl -X POST http://127.0.0.1:3000/v1/memories \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "external_id": "profile",
+    "content": "Alice likes rust and sqlite",
+    "metadata": {"source": "daemon"}
+  }'
+
+# 13) daemon recall
+curl -X POST http://127.0.0.1:3000/v1/recall \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "query": "rust sqlite",
+    "limit": 3
+  }'
+
+# 14) daemon audit read
+curl -X POST http://127.0.0.1:3000/v1/audit \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "limit": 20
+  }'
 ```
 
 ## Verification Gates
@@ -117,8 +170,10 @@ cargo test --workspace
 
 - Namespace is required in every operation, including `audit`.
 - CLI defaults to `AllowAllPolicy` when `--policy-file` is omitted.
+- `loong-memoryd` also defaults to `AllowAllPolicy` when `--policy-file` is omitted.
 - Policy is checked before store access.
 - Static JSON policy files can grant namespace-level and principal+namespace actions.
+- HTTP service routes require `x-loong-principal` on protected operations.
 - All actions emit auditable events (allow/deny + operation detail).
 - Audit reads are policy-gated and returned history excludes self-generated audit-read events.
 - Audit persistence surfaces write failures instead of silently dropping events.

--- a/crates/loong-memoryd/Cargo.toml
+++ b/crates/loong-memoryd/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "loong-memoryd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+clap.workspace = true
+loong-memory-core = { path = "../loong-memory-core" }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+reqwest.workspace = true
+tempfile.workspace = true

--- a/crates/loong-memoryd/src/lib.rs
+++ b/crates/loong-memoryd/src/lib.rs
@@ -1,0 +1,408 @@
+#![forbid(unsafe_code)]
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{
+    extract::{rejection::JsonRejection, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use loong_memory_core::{
+    AllowAllPolicy, DeterministicHashEmbedder, EmbeddingProvider, EngineConfig, LoongMemoryError,
+    MemoryEngine, MemoryGetRequest, MemoryPutRequest, OperationContext, PolicyEngine,
+    RecallRequest, ScoreWeights, SqliteAuditSink, SqliteStore, StaticPolicy, StaticPolicyConfig,
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tracing::error;
+
+pub const PRINCIPAL_HEADER: &str = "x-loong-principal";
+
+#[derive(Debug, Clone)]
+pub struct ServiceConfig {
+    db_path: PathBuf,
+    policy_file: Option<PathBuf>,
+}
+
+impl ServiceConfig {
+    pub fn new(db_path: PathBuf, policy_file: Option<PathBuf>) -> Self {
+        Self {
+            db_path,
+            policy_file,
+        }
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub fn policy_file(&self) -> Option<&Path> {
+        self.policy_file.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyMode {
+    AllowAll,
+    Static,
+}
+
+#[derive(Clone)]
+pub struct ServiceState {
+    db_path: PathBuf,
+    policy: Arc<dyn PolicyEngine>,
+    embedder: Arc<dyn EmbeddingProvider>,
+    policy_mode: PolicyMode,
+}
+
+impl ServiceState {
+    pub fn from_config(config: &ServiceConfig) -> Result<Self> {
+        let (policy, policy_mode) = load_policy(config.policy_file())?;
+        Ok(Self {
+            db_path: config.db_path().to_path_buf(),
+            policy,
+            embedder: Arc::new(DeterministicHashEmbedder::default()),
+            policy_mode,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RecallRequestBody {
+    namespace: String,
+    query: String,
+    #[serde(default = "default_recall_limit")]
+    limit: usize,
+    #[serde(default = "default_lexical_weight")]
+    lexical_weight: f32,
+    #[serde(default = "default_vector_weight")]
+    vector_weight: f32,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditRequestBody {
+    namespace: String,
+    #[serde(default = "default_audit_limit")]
+    limit: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+    db: String,
+    policy_mode: PolicyMode,
+}
+
+#[derive(Debug, Serialize)]
+struct CountEnvelope<T> {
+    count: usize,
+    #[serde(flatten)]
+    inner: T,
+}
+
+#[derive(Debug, Serialize)]
+struct HitsBody {
+    hits: Vec<loong_memory_core::RecallHit>,
+}
+
+#[derive(Debug, Serialize)]
+struct AuditEventsBody {
+    events: Vec<loong_memory_core::AuditEvent>,
+}
+
+#[derive(Debug)]
+struct ApiError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorEnvelope {
+    error: ErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    code: &'static str,
+    message: String,
+}
+
+impl ApiError {
+    fn new(status: StatusCode, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+
+    fn validation(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, "validation_failed", message)
+    }
+
+    fn unauthorized(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, "missing_principal", message)
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(ErrorEnvelope {
+                error: ErrorBody {
+                    code: self.code,
+                    message: self.message,
+                },
+            }),
+        )
+            .into_response()
+    }
+}
+
+impl From<LoongMemoryError> for ApiError {
+    fn from(err: LoongMemoryError) -> Self {
+        match err {
+            LoongMemoryError::Validation(message) => ApiError::validation(message),
+            LoongMemoryError::PolicyDenied(message) => {
+                ApiError::new(StatusCode::FORBIDDEN, "policy_denied", message)
+            }
+            LoongMemoryError::NotFound => {
+                ApiError::new(StatusCode::NOT_FOUND, "not_found", "not found")
+            }
+            LoongMemoryError::Storage(message) | LoongMemoryError::Internal(message) => {
+                error!(error = %message, "service request failed with internal/storage error");
+                ApiError::internal("internal error")
+            }
+            LoongMemoryError::NotImplemented(message) => {
+                error!(error = %message, "service request failed with internal/storage error");
+                ApiError::internal("internal error")
+            }
+        }
+    }
+}
+
+impl From<JsonRejection> for ApiError {
+    fn from(rejection: JsonRejection) -> Self {
+        ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "invalid_json",
+            rejection.body_text(),
+        )
+    }
+}
+
+pub fn app(state: ServiceState) -> Router {
+    Router::new()
+        .route("/healthz", get(health))
+        .route("/v1/memories", post(put_memory))
+        .route("/v1/memories/get", post(get_memory))
+        .route("/v1/recall", post(recall))
+        .route("/v1/audit", post(audit))
+        .with_state(state)
+}
+
+pub async fn serve_with_shutdown<F>(
+    listener: TcpListener,
+    state: ServiceState,
+    shutdown: F,
+) -> Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    axum::serve(listener, app(state))
+        .with_graceful_shutdown(shutdown)
+        .await
+        .context("serve loong-memoryd")?;
+    Ok(())
+}
+
+async fn health(State(state): State<ServiceState>) -> Result<Json<HealthResponse>, ApiError> {
+    let db_path = state.db_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), LoongMemoryError> {
+        let _store = SqliteStore::open(&db_path)?;
+        let _audit = SqliteAuditSink::open(&db_path)?;
+        Ok(())
+    })
+    .await
+    .map_err(|err| {
+        error!(error = %err, "health worker panicked");
+        ApiError::internal("internal error")
+    })?
+    .map_err(ApiError::from)?;
+
+    Ok(Json(HealthResponse {
+        status: "ok",
+        service: "loong-memoryd",
+        db: state.db_path.display().to_string(),
+        policy_mode: state.policy_mode,
+    }))
+}
+
+async fn put_memory(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<MemoryPutRequest>, JsonRejection>,
+) -> Result<Json<loong_memory_core::MemoryRecord>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let record = with_engine(state, principal, move |engine, ctx| engine.put(&ctx, &req)).await?;
+    Ok(Json(record))
+}
+
+async fn get_memory(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<MemoryGetRequest>, JsonRejection>,
+) -> Result<Json<loong_memory_core::MemoryRecord>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let record = with_engine(state, principal, move |engine, ctx| engine.get(&ctx, &req)).await?;
+    Ok(Json(record))
+}
+
+async fn recall(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<RecallRequestBody>, JsonRejection>,
+) -> Result<Json<CountEnvelope<HitsBody>>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let weights = normalize_weights(req.lexical_weight, req.vector_weight)?;
+    let request = RecallRequest {
+        namespace: req.namespace,
+        query: req.query,
+        limit: req.limit,
+        weights,
+    };
+    let hits = with_engine(state, principal, move |engine, ctx| {
+        engine.recall(&ctx, &request)
+    })
+    .await?;
+    Ok(Json(CountEnvelope {
+        count: hits.len(),
+        inner: HitsBody { hits },
+    }))
+}
+
+async fn audit(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<AuditRequestBody>, JsonRejection>,
+) -> Result<Json<CountEnvelope<AuditEventsBody>>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let events = with_engine(state, principal, move |engine, ctx| {
+        engine.audit_events(&ctx, &req.namespace, req.limit)
+    })
+    .await?;
+    Ok(Json(CountEnvelope {
+        count: events.len(),
+        inner: AuditEventsBody { events },
+    }))
+}
+
+fn default_recall_limit() -> usize {
+    5
+}
+
+fn default_lexical_weight() -> f32 {
+    0.55
+}
+
+fn default_vector_weight() -> f32 {
+    0.45
+}
+
+fn default_audit_limit() -> usize {
+    50
+}
+
+fn extract_principal(headers: &HeaderMap) -> Result<String, ApiError> {
+    let Some(value) = headers.get(PRINCIPAL_HEADER) else {
+        return Err(ApiError::unauthorized(format!(
+            "missing required header {PRINCIPAL_HEADER}"
+        )));
+    };
+    let principal = value
+        .to_str()
+        .map_err(|_| ApiError::unauthorized(format!("invalid header {PRINCIPAL_HEADER}")))?
+        .trim()
+        .to_owned();
+    if principal.is_empty() {
+        return Err(ApiError::unauthorized(format!(
+            "missing required header {PRINCIPAL_HEADER}"
+        )));
+    }
+    Ok(principal)
+}
+
+fn normalize_weights(lexical: f32, vector: f32) -> Result<ScoreWeights, ApiError> {
+    if !lexical.is_finite() || !vector.is_finite() {
+        return Err(ApiError::validation("weights must be finite numbers"));
+    }
+    let sum = lexical + vector;
+    if sum <= 0.0 {
+        return Err(ApiError::validation(
+            "lexical/vector weights must sum to a positive value",
+        ));
+    }
+    Ok(ScoreWeights {
+        lexical: lexical / sum,
+        vector: vector / sum,
+    })
+}
+
+async fn with_engine<R, F>(state: ServiceState, principal: String, op: F) -> Result<R, ApiError>
+where
+    R: Send + 'static,
+    F: FnOnce(&mut MemoryEngine<SqliteStore>, OperationContext) -> Result<R, LoongMemoryError>
+        + Send
+        + 'static,
+{
+    let db_path = state.db_path.clone();
+    let policy = Arc::clone(&state.policy);
+    let embedder = Arc::clone(&state.embedder);
+
+    let result = tokio::task::spawn_blocking(move || -> Result<R, LoongMemoryError> {
+        let store = SqliteStore::open(&db_path)?;
+        let audit = Arc::new(SqliteAuditSink::open(&db_path)?);
+        let mut engine = MemoryEngine::new(store, policy, embedder, audit, EngineConfig::default());
+        op(&mut engine, OperationContext::new(principal))
+    })
+    .await
+    .map_err(|err| {
+        error!(error = %err, "request worker panicked");
+        ApiError::internal("internal error")
+    })?;
+
+    result.map_err(ApiError::from)
+}
+
+fn load_policy(policy_file: Option<&Path>) -> Result<(Arc<dyn PolicyEngine>, PolicyMode)> {
+    match policy_file {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .with_context(|| format!("read policy file {}", path.display()))?;
+            let config: StaticPolicyConfig = serde_json::from_str(&raw)
+                .with_context(|| format!("parse policy file {}", path.display()))?;
+            Ok((
+                Arc::new(StaticPolicy::from_config(config)),
+                PolicyMode::Static,
+            ))
+        }
+        None => Ok((Arc::new(AllowAllPolicy), PolicyMode::AllowAll)),
+    }
+}

--- a/crates/loong-memoryd/src/main.rs
+++ b/crates/loong-memoryd/src/main.rs
@@ -1,0 +1,50 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use loong_memoryd::{serve_with_shutdown, ServiceConfig, ServiceState};
+use tokio::net::TcpListener;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(name = "loong-memoryd")]
+#[command(about = "Minimal loong-memory HTTP daemon", version)]
+struct Cli {
+    #[arg(long, default_value = "./loong-memory.db")]
+    db: PathBuf,
+    #[arg(long, default_value = "127.0.0.1:3000")]
+    listen_addr: SocketAddr,
+    #[arg(long)]
+    policy_file: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+
+    let cli = Cli::parse();
+    let config = ServiceConfig::new(cli.db.clone(), cli.policy_file.clone());
+    let state = ServiceState::from_config(&config).context("build loong-memoryd state")?;
+    let listener = TcpListener::bind(cli.listen_addr)
+        .await
+        .with_context(|| format!("bind loong-memoryd listener {}", cli.listen_addr))?;
+    let address = listener
+        .local_addr()
+        .context("resolve loong-memoryd bound address")?;
+
+    info!(
+        address = %address,
+        db = %cli.db.display(),
+        "starting loong-memoryd"
+    );
+
+    serve_with_shutdown(listener, state, async {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            tracing::warn!(error = %err, "failed to listen for ctrl-c");
+        }
+    })
+    .await
+}

--- a/crates/loong-memoryd/tests/http_service_integration.rs
+++ b/crates/loong-memoryd/tests/http_service_integration.rs
@@ -1,0 +1,244 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use loong_memoryd::{serve_with_shutdown, ServiceConfig, ServiceState};
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+
+struct TestServer {
+    _temp_dir: TempDir,
+    client: Client,
+    base_url: String,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    join_handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    async fn spawn(policy_file: Option<&Path>) -> Result<Self> {
+        let temp_dir = TempDir::new().context("create temp dir")?;
+        let db_path = temp_dir.path().join("loong-memory.db");
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind tcp listener")?;
+        let address = listener.local_addr().context("read listener address")?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let config = ServiceConfig::new(db_path, policy_file.map(PathBuf::from));
+        let state = ServiceState::from_config(&config)?;
+
+        let join_handle = tokio::spawn(async move {
+            let shutdown = async move {
+                let _ = shutdown_rx.await;
+            };
+            if let Err(err) = serve_with_shutdown(listener, state, shutdown).await {
+                panic!("server exited with error: {err}");
+            }
+        });
+
+        Ok(Self {
+            _temp_dir: temp_dir,
+            client: Client::new(),
+            base_url: format!("http://{address}"),
+            shutdown_tx: Some(shutdown_tx),
+            join_handle,
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        self.join_handle.abort();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn healthz_returns_ok_without_principal() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let response = server.client.get(server.url("/healthz")).send().await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().await?;
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["service"], "loong-memoryd");
+    assert_eq!(body["policy_mode"], "allow_all");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_requires_principal_header() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "missing_principal");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_and_get_roundtrip_over_http() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let put_response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust and sqlite",
+            "metadata": {"source": "seed"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let get_response = server
+        .client
+        .post(server.url("/v1/memories/get"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile"
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let body: Value = get_response.json().await?;
+    assert_eq!(body["namespace"], "agent-demo");
+    assert_eq!(body["external_id"], "profile");
+    assert_eq!(body["content"], "Alice likes rust and sqlite");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recall_returns_relevant_hit() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let put_response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust and sqlite",
+            "metadata": {"source": "seed"}
+        }))
+        .send()
+        .await?;
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let recall_response = server
+        .client
+        .post(server.url("/v1/recall"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "query": "rust sqlite",
+            "limit": 3
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(recall_response.status(), StatusCode::OK);
+    let body: Value = recall_response.json().await?;
+    assert_eq!(body["count"], 1);
+    assert_eq!(body["hits"][0]["record"]["external_id"], "profile");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn audit_returns_namespace_history_without_self_pollution() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let put_response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust and sqlite",
+            "metadata": {"source": "seed"}
+        }))
+        .send()
+        .await?;
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let audit_response = server
+        .client
+        .post(server.url("/v1/audit"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "limit": 20
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(audit_response.status(), StatusCode::OK);
+    let body: Value = audit_response.json().await?;
+    assert!(body["count"].as_u64().unwrap_or(0) >= 2);
+    let events = body["events"]
+        .as_array()
+        .context("events response should be an array")?;
+    let actions: Vec<&str> = events
+        .iter()
+        .filter_map(|event| event["action"].as_str())
+        .collect();
+    assert!(actions.contains(&"put"));
+    assert!(!actions.contains(&"audit_events"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn static_policy_denial_returns_forbidden() -> Result<()> {
+    let temp_dir = TempDir::new().context("create policy temp dir")?;
+    let policy_path = temp_dir.path().join("policy.json");
+    std::fs::write(&policy_path, "{}").context("write policy file")?;
+
+    let server = TestServer::spawn(Some(&policy_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "policy_denied");
+    Ok(())
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# loong-memory Architecture (Phase 1)
+# loong-memory Architecture (Phase 1 + Phase 2 Bootstrap)
 
 ## 1. Design Goals
 
@@ -85,6 +85,27 @@ For each query:
 - Deterministic sort:
   - `hybrid_score DESC`, `updated_at DESC`, `id ASC`.
 
+### L4 Service Layer (`loong-memoryd`)
+
+Phase 2 now starts with a minimal HTTP JSON daemon:
+
+- `GET /healthz`
+- `POST /v1/memories`
+- `POST /v1/memories/get`
+- `POST /v1/recall`
+- `POST /v1/audit`
+
+Transport behavior:
+
+- protected routes require `x-loong-principal`
+- request bodies map closely to existing engine request types
+- each request creates a fresh `MemoryEngine` against the configured SQLite path
+- synchronous SQLite/engine work is executed inside `tokio::task::spawn_blocking`
+- errors are mapped into structured HTTP JSON responses
+
+This keeps the daemon thin. The control-plane rules still live in
+`MemoryEngine`, not in the transport handlers.
+
 ## 3. Data Model
 
 ### MemoryRecord
@@ -109,6 +130,8 @@ For each query:
 - Policy gate is enforced before every operation.
 - CLI can load a JSON `StaticPolicyConfig` via `--policy-file`; without it,
   the CLI preserves current local-operator ergonomics with `AllowAllPolicy`.
+- `loong-memoryd` can load the same JSON `StaticPolicyConfig`; protected routes
+  require `x-loong-principal` so transport requests carry an explicit principal.
 - Maintenance operations (`vector_health`, `vector_repair`) are executed through
   engine-level policy checks and audit events, not direct CLI store bypass.
 - Audit reads are namespace-scoped and require `Action::AuditRead`.
@@ -157,6 +180,8 @@ Current integration tests validate:
 - vector repair workflow (`dry-run` planning + transactional `apply`)
 - principal+namespace scoped static policy behavior
 - audit SQLite persistence/filter/limit/error behavior
+- daemon health, principal enforcement, put/get roundtrip, recall, policy deny,
+  and audit-read behavior over HTTP
 
 Quality gates:
 

--- a/docs/plans/2026-03-15-loong-memoryd-http-design.md
+++ b/docs/plans/2026-03-15-loong-memoryd-http-design.md
@@ -1,0 +1,323 @@
+# loong-memoryd Minimal HTTP Service Design
+
+Date: 2026-03-15
+Owner: chumyin
+Issue: #4
+
+## 1. Context
+
+`loong-memory` has completed a strong Phase 1:
+
+- `MemoryEngine` already centralizes validation, policy checks, store access,
+  and audit emission.
+- the CLI can now load a static JSON policy file and route audit reads through
+  engine-level authorization.
+- SQLite durability, bounded recall, and audit persistence semantics are
+  already covered by deterministic integration tests.
+
+What the repository still lacks is the first Phase 2 transport/runtime surface
+from the roadmap: a standalone daemon process that exposes the engine over a
+service boundary.
+
+## 2. Problem Statement
+
+The project currently requires in-process Rust usage or direct CLI execution for
+every memory operation. That keeps the engine reusable, but it prevents the
+repository from demonstrating:
+
+- a daemonized operational runtime
+- a transport boundary for future SDK clients
+- service-level health verification
+- a concrete authn/authz envelope at the transport edge
+
+Without a service slice, the roadmap's Phase 2 story is still conceptual rather
+than delivered.
+
+## 3. Goals
+
+1. Add a standalone `loong-memoryd` binary to the workspace.
+2. Expose a minimal HTTP JSON API that reuses existing engine semantics.
+3. Require an explicit principal header for protected operations.
+4. Start the daemon from a configured SQLite database path and optional static
+   policy file.
+5. Provide a structured health endpoint for operator and CI verification.
+6. Add deterministic tests covering transport behavior and policy enforcement.
+7. Update docs so repository status matches shipped behavior.
+
+## 4. Non-Goals
+
+- gRPC in this round
+- Rust or TypeScript SDKs in this round
+- dynamic policy reload
+- bearer-token verification or external identity providers
+- metrics, tracing export, or OpenTelemetry wiring
+- maintenance endpoints for `vector_health` / `vector_repair`
+- reworking store internals into async APIs
+
+## 5. Approaches Considered
+
+### Approach A: Full REST Surface with Resource-Oriented Routes
+
+Expose canonical REST resources immediately, such as:
+
+- `POST /v1/namespaces/:namespace/memories`
+- `GET /v1/namespaces/:namespace/memories/:id`
+- `GET /v1/namespaces/:namespace/audit`
+
+Pros:
+
+- closer to a polished public API
+- cleaner URLs for long-term SDK generation
+
+Cons:
+
+- selector semantics (`id` XOR `external_id`) become awkward immediately
+- more route and serialization work for a first service slice
+- more design surface than needed to validate Phase 2 architecture
+
+### Approach B: Minimal HTTP JSON Action Endpoints
+
+Ship a small daemon with one health route and a few JSON endpoints that map
+almost 1:1 onto existing engine request types.
+
+Pros:
+
+- fastest path to a real daemon
+- minimal translation layer around `MemoryEngine`
+- easy to test deterministically
+- preserves current semantics without over-designing the public API
+
+Cons:
+
+- less REST-like
+- likely not the final long-term public transport shape
+
+### Approach C: Jump Straight to gRPC
+
+Use protobuf contracts and a gRPC server as the first network transport.
+
+Pros:
+
+- strong future SDK/codegen story
+- explicit schemas from the start
+
+Cons:
+
+- much larger dependency and tooling step
+- slower path to the first working daemon
+- higher design lock-in before validating runtime assumptions
+
+## 6. Chosen Approach
+
+Approach B.
+
+This round should optimize for shipping the first production-shaped daemon
+boundary, not for prematurely finalizing the entire external API style.
+
+## 7. Proposed Runtime Shape
+
+## 7.1 New Workspace Crate
+
+Add a new crate:
+
+- `crates/loong-memoryd`
+
+The crate should contain:
+
+- a library layer for service configuration, router construction, request
+  handlers, and error mapping
+- a binary entrypoint that parses CLI flags, initializes state, binds the TCP
+  listener, and serves until shutdown
+
+## 7.2 Configuration Model
+
+The daemon should start from explicit CLI flags:
+
+- `--db <path>`: SQLite database path, default `./loong-memory.db`
+- `--listen-addr <addr>`: socket address, default `127.0.0.1:3000`
+- `--policy-file <path>`: optional static JSON policy file
+
+Runtime state should store:
+
+- database path
+- listen address
+- loaded policy engine
+- deterministic embedder
+
+This keeps startup simple and avoids committing to a config-file format for the
+daemon in the same round as the first transport slice.
+
+## 7.3 Transport Surface
+
+Expose the following endpoints:
+
+- `GET /healthz`
+- `POST /v1/memories`
+- `POST /v1/memories/get`
+- `POST /v1/recall`
+- `POST /v1/audit`
+
+Rationale:
+
+- keeps scope tight
+- covers write, point-read, ranked read, and audit-read semantics
+- preserves current selector and recall request shapes cleanly
+
+## 7.4 Principal Envelope
+
+Protected routes must require:
+
+- `x-loong-principal: <principal>`
+
+Behavior:
+
+- missing header returns `401 Unauthorized`
+- blank header returns `401 Unauthorized`
+- health endpoint does not require a principal
+
+This is intentionally minimal. It is not presented as strong authentication,
+only as the first transport identity envelope that maps onto the engine's
+principal-aware policy model.
+
+## 7.5 Request Execution Strategy
+
+The core engine and SQLite layers are synchronous. Sharing a single mutable
+engine in async handlers would force a hot lock and block reactor threads.
+
+Instead, each protected request should:
+
+1. clone immutable app state (`db_path`, `policy`, `embedder`)
+2. enter `tokio::task::spawn_blocking`
+3. create a fresh `SqliteStore`, `SqliteAuditSink`, and `MemoryEngine`
+4. execute the requested engine operation
+5. return the serialized result
+
+Why this shape:
+
+- avoids cross-request mutable state
+- keeps synchronous SQLite work off async runtime workers
+- reuses the same construction pattern already used by the CLI
+- preserves current audit and policy semantics exactly
+
+## 7.6 Error Model
+
+Map engine and transport failures into structured JSON:
+
+```json
+{
+  "error": {
+    "code": "policy_denied",
+    "message": "policy denied: ..."
+  }
+}
+```
+
+Initial mapping:
+
+- validation -> `400 Bad Request`, `validation_failed`
+- policy denied -> `403 Forbidden`, `policy_denied`
+- not found -> `404 Not Found`, `not_found`
+- missing principal -> `401 Unauthorized`, `missing_principal`
+- unsupported method/route -> framework default `404`
+- storage/internal/spawn failures -> `500 Internal Server Error`,
+  `internal_error`
+
+## 7.7 Response Shape
+
+For operation endpoints, prefer direct JSON payloads over envelope-heavy
+wrappers, except when a count is useful:
+
+- `POST /v1/memories` -> `MemoryRecord`
+- `POST /v1/memories/get` -> `MemoryRecord`
+- `POST /v1/recall` -> `{ "count": N, "hits": [...] }`
+- `POST /v1/audit` -> `{ "count": N, "events": [...] }`
+- `GET /healthz` -> health object
+
+Proposed health response:
+
+```json
+{
+  "status": "ok",
+  "service": "loong-memoryd",
+  "db": "./loong-memory.db",
+  "policy_mode": "allow_all"
+}
+```
+
+If a policy file is supplied, `policy_mode` becomes `static`.
+
+## 7.8 Health Semantics
+
+`GET /healthz` should verify more than process liveness:
+
+- open the configured SQLite store successfully
+- open the configured SQLite audit sink successfully
+- return structured JSON when initialization succeeds
+
+If the database cannot be opened, the endpoint should fail with `500` and a
+structured error payload. This keeps health checks honest.
+
+## 7.9 Documentation Changes
+
+Update:
+
+- `README.md`
+- `docs/architecture.md`
+- `docs/roadmap.md`
+
+The docs should describe:
+
+- the new `loong-memoryd` crate and HTTP daemon surface
+- minimal authn envelope via `x-loong-principal`
+- health endpoint and example requests
+- Phase 2 status as "started with minimal HTTP daemon surface"
+
+## 8. Testing Strategy
+
+## 8.1 Handler/Transport Tests
+
+Add integration tests for:
+
+- `GET /healthz` succeeds without principal
+- protected endpoint rejects missing principal
+- `POST /v1/memories` followed by `POST /v1/memories/get` succeeds
+- `POST /v1/recall` returns relevant results
+- static policy denial returns `403`
+- `POST /v1/audit` returns existing namespace history and preserves current
+  audit-read semantics
+
+## 8.2 Daemon Runtime Test
+
+Add at least one test that boots the router/server shape with an ephemeral
+database and exercises the HTTP layer end to end. Use deterministic inputs and
+keep the test local-only.
+
+## 8.3 Verification Gates
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+## 9. Risks and Mitigations
+
+Risk: blocking SQLite work stalls async request handling.
+
+Mitigation:
+
+- execute engine/store work in `spawn_blocking`
+- keep app state immutable and cheap to clone
+
+Risk: transport code drifts from engine semantics.
+
+Mitigation:
+
+- keep endpoint request types close to existing model types
+- route all protected operations through `MemoryEngine`
+- add end-to-end tests for policy, audit, and recall behavior
+
+Risk: the first HTTP surface is mistaken for a final public API.
+
+Mitigation:
+
+- document this explicitly as the minimal Phase 2 service slice
+- avoid over-committing to REST or SDK generation in this round

--- a/docs/plans/2026-03-15-loong-memoryd-http.md
+++ b/docs/plans/2026-03-15-loong-memoryd-http.md
@@ -1,0 +1,269 @@
+# loong-memoryd Minimal HTTP Service Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal `loong-memoryd` daemon that exposes health, put, get, recall, and audit operations over HTTP JSON while preserving the existing engine, policy, and audit semantics.
+
+**Architecture:** Add a new `crates/loong-memoryd` workspace crate built on `axum` + `tokio`. Keep app state immutable, require `x-loong-principal` for protected routes, and run synchronous SQLite/engine work inside `spawn_blocking` with per-request engine construction.
+
+**Tech Stack:** Rust, `axum`, `tokio`, `serde`, `tower`, `reqwest`, existing `loong-memory-core`
+
+---
+
+### Task 1: Add the new daemon crate skeleton
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/loong-memoryd/Cargo.toml`
+- Create: `crates/loong-memoryd/src/lib.rs`
+- Create: `crates/loong-memoryd/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Create an integration test module placeholder under `crates/loong-memoryd/tests/http_service_integration.rs` that imports the future crate and fails because the crate/router does not exist yet.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd`
+Expected: FAIL because the package or crate has not been added yet.
+
+**Step 3: Write minimal implementation**
+
+- add the crate to the workspace
+- declare dependencies for `axum`, `tokio`, `serde`, `serde_json`, `anyhow`, `thiserror`, `tower`, and `reqwest`
+- add a stub library with exported config/state placeholders
+- add a stub binary that parses CLI flags and exits cleanly
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd`
+Expected: PASS for the crate skeleton with placeholder coverage.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/loong-memoryd
+git commit -m "feat: add loong-memoryd crate skeleton"
+```
+
+### Task 2: Add health endpoint and structured error model
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/src/main.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+- `GET /healthz` returns `200`
+- response JSON includes `status`, `service`, and `policy_mode`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd healthz`
+Expected: FAIL because no router/health handler exists.
+
+**Step 3: Write minimal implementation**
+
+- add `ServiceConfig`, `PolicyMode`, and immutable app state
+- add router construction with `GET /healthz`
+- open SQLite store/audit in the health handler to ensure honest readiness
+- add structured JSON error responses and HTTP status mapping helpers
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd healthz`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/src/main.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: add loong-memoryd health endpoint"
+```
+
+### Task 3: Enforce principal header and request helpers
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add a test proving a protected route returns `401` without `x-loong-principal`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd missing_principal`
+Expected: FAIL because protected-route principal extraction is not implemented.
+
+**Step 3: Write minimal implementation**
+
+- add shared request extraction/helper for `x-loong-principal`
+- return a structured unauthorized error for missing or blank principals
+- add request DTOs for put/get/recall/audit bodies
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd missing_principal`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: require principal header for service requests"
+```
+
+### Task 4: Implement put/get endpoints through `MemoryEngine`
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add an end-to-end test:
+
+- `POST /v1/memories` stores a record
+- `POST /v1/memories/get` fetches it by `external_id`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd put_and_get`
+Expected: FAIL because handlers are not implemented.
+
+**Step 3: Write minimal implementation**
+
+- add a helper to run synchronous engine work inside `spawn_blocking`
+- build a fresh engine per request from app state
+- map request DTOs into `MemoryPutRequest` / `MemoryGetRequest`
+- serialize `MemoryRecord` responses
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd put_and_get`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: add loong-memoryd put and get endpoints"
+```
+
+### Task 5: Implement recall and audit endpoints with policy-aware errors
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+- recall returns a relevant hit for stored content
+- audit returns namespace history after writes
+- policy denial from a static policy file returns `403`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd recall`
+Run: `cargo test -p loong-memoryd audit`
+Expected: FAIL because recall/audit handlers and error mapping are incomplete.
+
+**Step 3: Write minimal implementation**
+
+- implement `POST /v1/recall`
+- implement `POST /v1/audit`
+- normalize recall weights the same way the CLI does
+- map `LoongMemoryError::PolicyDenied` to `403`
+- keep count-bearing response envelopes for recall and audit
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd recall`
+Run: `cargo test -p loong-memoryd audit`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: add loong-memoryd recall and audit endpoints"
+```
+
+### Task 6: Wire the binary runtime and update repository docs
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/main.rs`
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/roadmap.md`
+
+**Step 1: Write the failing test**
+
+If practical, add a smoke test or command-level assertion that the binary config can be parsed and server state can be constructed from CLI inputs.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd main`
+Expected: FAIL until runtime wiring and config parsing are finalized.
+
+**Step 3: Write minimal implementation**
+
+- finalize CLI parsing for `--db`, `--listen-addr`, and `--policy-file`
+- start the Axum server from a bound listener
+- document service usage and curl examples in `README.md`
+- update architecture and roadmap docs to describe the new daemon slice
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd main`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/main.rs README.md docs/architecture.md docs/roadmap.md
+git commit -m "docs: document loong-memoryd service surface"
+```
+
+### Task 7: Run full workspace verification and prepare GitHub delivery
+
+**Files:**
+- Modify: `docs/research/phase2-service-evaluation-2026-03-15.md`
+
+**Step 1: Write the failing test**
+
+No new product test. This task is for verification and evidence capture.
+
+**Step 2: Run test to verify it fails**
+
+Not applicable.
+
+**Step 3: Write minimal implementation**
+
+- summarize design decisions, verification results, and residual risks in a new research note
+- inspect `git status --short` and staged diff isolation
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/research/phase2-service-evaluation-2026-03-15.md
+git commit -m "feat: ship minimal loong-memoryd service surface"
+```

--- a/docs/research/phase2-service-evaluation-2026-03-15.md
+++ b/docs/research/phase2-service-evaluation-2026-03-15.md
@@ -1,0 +1,93 @@
+# Phase 2 Service Evaluation (2026-03-15)
+
+## Summary
+
+This round delivers the first Phase 2 runtime boundary for `loong-memory`:
+`loong-memoryd`, a standalone HTTP JSON daemon that reuses the existing engine,
+policy, and audit contracts.
+
+## Why This Was the Right Next Step
+
+Before this change, the repository already had a solid engine and CLI, but it
+still lacked any transport boundary. That meant:
+
+- no daemonized runtime
+- no service-level health verification
+- no concrete transport principal envelope
+- no direct path toward future SDK clients
+
+Adding the smallest real daemon slice closed the largest remaining delivery gap
+without overcommitting to a final public API shape.
+
+## Design Decisions
+
+### 1. HTTP JSON Before gRPC
+
+HTTP JSON was chosen as the first transport because it is the fastest path to a
+production-shaped daemon with low integration overhead. gRPC remains a later
+Phase 2 expansion, not a blocker for validating the runtime boundary.
+
+### 2. Thin Transport Layer
+
+Handlers delegate to `MemoryEngine` instead of re-implementing validation,
+policy, or audit logic. This keeps the transport layer small and preserves the
+repository's existing trust boundary.
+
+### 3. Explicit Principal Header
+
+Protected routes require `x-loong-principal`. This is intentionally minimal and
+maps directly onto the existing engine policy model without pretending to be a
+complete authentication solution.
+
+### 4. Per-Request Engine Construction
+
+The core engine and SQLite store remain synchronous. Rather than sharing a
+mutable engine in async handlers, the daemon creates a fresh engine per request
+inside `spawn_blocking`. This avoids hot locks and keeps blocking work off the
+reactor.
+
+## Scope Delivered
+
+- `crates/loong-memoryd`
+- `GET /healthz`
+- `POST /v1/memories`
+- `POST /v1/memories/get`
+- `POST /v1/recall`
+- `POST /v1/audit`
+- structured HTTP error mapping
+- startup config via `--db`, `--listen-addr`, `--policy-file`
+- updated repository docs
+
+## Verification
+
+Local verification passed:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+Covered HTTP integration behaviors:
+
+- health endpoint does not require a principal
+- protected routes reject missing principal headers
+- put/get roundtrip succeeds over the daemon surface
+- recall returns relevant results over HTTP
+- static policy denial returns `403`
+- audit read returns namespace history without self-pollution
+
+## Residual Gaps
+
+This is a bootstrap slice, not the full Phase 2 end state. Still missing:
+
+- delete and maintenance HTTP routes
+- gRPC transport
+- SDK clients
+- metrics/tracing export
+- stronger transport authentication and policy reload
+
+## Outcome
+
+The repository now has a credible Phase 2 starting point: a real daemon
+boundary, transport-level identity propagation, structured health checks, and
+end-to-end service tests. That materially improves delivery completeness over a
+CLI-only Phase 1 story.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,12 +7,19 @@
 - CLI for operational CRUD and audit inspection
 - baseline integration tests and strict lint gates
 
-## Phase 2: Transport + SDK Surface
+## Phase 2 (Started): Transport + SDK Surface
 
-- standalone daemon process (`loong-memoryd`)
-- gRPC/HTTP APIs with authn/authz envelope
+Implemented:
+
+- standalone daemon process bootstrap (`loong-memoryd`)
+- minimal HTTP JSON API with principal header envelope
+- structured health checks
+
+Remaining:
+
+- broader HTTP/gRPC surface
 - Rust + TypeScript SDK clients
-- metrics/tracing integration and structured health checks
+- metrics/tracing integration
 
 ## Phase 3: Scalability and Isolation Hardening
 


### PR DESCRIPTION
## Summary
- add a new `loong-memoryd` workspace crate with a minimal HTTP JSON service surface for health, put, get, recall, and audit operations
- preserve existing engine, policy, and audit semantics by constructing a fresh `MemoryEngine` per request inside blocking workers and requiring `x-loong-principal` on protected routes
- update the README, architecture, roadmap, design/plan docs, and research notes to document the Phase 2 bootstrap daemon surface

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Closes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced loong-memoryd HTTP daemon for programmatic memory access
  * Added endpoints for health checks, memory operations, recall, and audit history
  * Principal header authentication support for protected endpoints
  * Per-request memory engine construction with configurable policies

* **Documentation**
  * Updated quick-start guide with daemon deployment instructions
  * Added architecture notes and design documentation for daemon operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->