### PR TITLE
feat: harden loong-memoryd transport surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ minimal daemon surface:
   - standalone HTTP JSON daemon
   - `GET /healthz`
   - `POST /v1/memories`
+  - `DELETE /v1/memories`
   - `POST /v1/memories/get`
   - `POST /v1/recall`
   - `POST /v1/audit`
+  - `POST /v1/vector-health`
+  - `POST /v1/vector-repair`
   - per-request `MemoryEngine` construction on blocking workers
   - transport-level principal envelope via `x-loong-principal`
 
@@ -153,6 +156,34 @@ curl -X POST http://127.0.0.1:3000/v1/audit \
   -d '{
     "namespace": "agent-demo",
     "limit": 20
+  }'
+
+# 15) daemon delete
+curl -X DELETE http://127.0.0.1:3000/v1/memories \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "external_id": "profile"
+  }'
+
+# 16) daemon vector health
+curl -X POST http://127.0.0.1:3000/v1/vector-health \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "invalid_sample_limit": 20
+  }'
+
+# 17) daemon vector repair dry-run
+curl -X POST http://127.0.0.1:3000/v1/vector-repair \
+  -H 'content-type: application/json' \
+  -H 'x-loong-principal: operator' \
+  -d '{
+    "namespace": "agent-demo",
+    "issue_sample_limit": 20,
+    "apply": false
   }'
 ```
 

--- a/crates/loong-memoryd/src/lib.rs
+++ b/crates/loong-memoryd/src/lib.rs
@@ -14,8 +14,9 @@ use axum::{
 };
 use loong_memory_core::{
     AllowAllPolicy, DeterministicHashEmbedder, EmbeddingProvider, EngineConfig, LoongMemoryError,
-    MemoryEngine, MemoryGetRequest, MemoryPutRequest, OperationContext, PolicyEngine,
-    RecallRequest, ScoreWeights, SqliteAuditSink, SqliteStore, StaticPolicy, StaticPolicyConfig,
+    MemoryDeleteRequest, MemoryEngine, MemoryGetRequest, MemoryPutRequest, OperationContext,
+    PolicyEngine, RecallRequest, ScoreWeights, SqliteAuditSink, SqliteStore, StaticPolicy,
+    StaticPolicyConfig,
 };
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
@@ -92,6 +93,22 @@ struct AuditRequestBody {
     limit: usize,
 }
 
+#[derive(Debug, Deserialize)]
+struct VectorHealthRequestBody {
+    namespace: String,
+    #[serde(default = "default_invalid_sample_limit")]
+    invalid_sample_limit: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct VectorRepairRequestBody {
+    namespace: String,
+    #[serde(default = "default_issue_sample_limit")]
+    issue_sample_limit: usize,
+    #[serde(default)]
+    apply: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct HealthResponse {
     status: &'static str,
@@ -115,6 +132,11 @@ struct HitsBody {
 #[derive(Debug, Serialize)]
 struct AuditEventsBody {
     events: Vec<loong_memory_core::AuditEvent>,
+}
+
+#[derive(Debug, Serialize)]
+struct OkBody {
+    ok: bool,
 }
 
 #[derive(Debug)]
@@ -207,10 +229,12 @@ impl From<JsonRejection> for ApiError {
 pub fn app(state: ServiceState) -> Router {
     Router::new()
         .route("/healthz", get(health))
-        .route("/v1/memories", post(put_memory))
+        .route("/v1/memories", post(put_memory).delete(delete_memory))
         .route("/v1/memories/get", post(get_memory))
         .route("/v1/recall", post(recall))
         .route("/v1/audit", post(audit))
+        .route("/v1/vector-health", post(vector_health))
+        .route("/v1/vector-repair", post(vector_repair))
         .with_state(state)
 }
 
@@ -273,6 +297,20 @@ async fn get_memory(
     Ok(Json(record))
 }
 
+async fn delete_memory(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<MemoryDeleteRequest>, JsonRejection>,
+) -> Result<Json<OkBody>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    with_engine(state, principal, move |engine, ctx| {
+        engine.delete(&ctx, &req)
+    })
+    .await?;
+    Ok(Json(OkBody { ok: true }))
+}
+
 async fn recall(
     State(state): State<ServiceState>,
     headers: HeaderMap,
@@ -314,6 +352,34 @@ async fn audit(
     }))
 }
 
+async fn vector_health(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<VectorHealthRequestBody>, JsonRejection>,
+) -> Result<Json<loong_memory_core::VectorHealthReport>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let report = with_engine(state, principal, move |engine, ctx| {
+        engine.vector_health(&ctx, &req.namespace, req.invalid_sample_limit)
+    })
+    .await?;
+    Ok(Json(report))
+}
+
+async fn vector_repair(
+    State(state): State<ServiceState>,
+    headers: HeaderMap,
+    body: Result<Json<VectorRepairRequestBody>, JsonRejection>,
+) -> Result<Json<loong_memory_core::VectorRepairReport>, ApiError> {
+    let principal = extract_principal(&headers)?;
+    let Json(req) = body.map_err(ApiError::from)?;
+    let report = with_engine(state, principal, move |engine, ctx| {
+        engine.vector_repair(&ctx, &req.namespace, req.issue_sample_limit, req.apply)
+    })
+    .await?;
+    Ok(Json(report))
+}
+
 fn default_recall_limit() -> usize {
     5
 }
@@ -328,6 +394,14 @@ fn default_vector_weight() -> f32 {
 
 fn default_audit_limit() -> usize {
     50
+}
+
+fn default_invalid_sample_limit() -> usize {
+    20
+}
+
+fn default_issue_sample_limit() -> usize {
+    20
 }
 
 fn extract_principal(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/crates/loong-memoryd/tests/http_service_integration.rs
+++ b/crates/loong-memoryd/tests/http_service_integration.rs
@@ -19,7 +19,14 @@ impl TestServer {
     async fn spawn(policy_file: Option<&Path>) -> Result<Self> {
         let temp_dir = TempDir::new().context("create temp dir")?;
         let db_path = temp_dir.path().join("loong-memory.db");
+        Self::spawn_with_db_path(temp_dir, db_path, policy_file).await
+    }
 
+    async fn spawn_with_db_path(
+        temp_dir: TempDir,
+        db_path: PathBuf,
+        policy_file: Option<&Path>,
+    ) -> Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .context("bind tcp listener")?;
@@ -240,5 +247,215 @@ async fn static_policy_denial_returns_forbidden() -> Result<()> {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let body: Value = response.json().await?;
     assert_eq!(body["error"]["code"], "policy_denied");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_removes_record_over_http() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let put_response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust and sqlite",
+            "metadata": {"source": "seed"}
+        }))
+        .send()
+        .await?;
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let delete_response = server
+        .client
+        .delete(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile"
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(delete_response.status(), StatusCode::OK);
+    let body: Value = delete_response.json().await?;
+    assert_eq!(body["ok"], true);
+
+    let get_response = server
+        .client
+        .post(server.url("/v1/memories/get"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile"
+        }))
+        .send()
+        .await?;
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_rejects_invalid_selector() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let delete_response = server
+        .client
+        .delete(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "id": "memory-id",
+            "external_id": "profile"
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(delete_response.status(), StatusCode::BAD_REQUEST);
+    let body: Value = delete_response.json().await?;
+    assert_eq!(body["error"]["code"], "validation_failed");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vector_health_returns_report_over_http() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let put_response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust and sqlite",
+            "metadata": {"source": "seed"}
+        }))
+        .send()
+        .await?;
+    assert_eq!(put_response.status(), StatusCode::OK);
+
+    let response = server
+        .client
+        .post(server.url("/v1/vector-health"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "invalid_sample_limit": 5
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().await?;
+    assert_eq!(body["namespace"], "agent-demo");
+    assert_eq!(body["total_rows"], 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vector_repair_returns_dry_run_report_over_http() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/vector-repair"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "issue_sample_limit": 5,
+            "apply": false
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().await?;
+    assert_eq!(body["namespace"], "agent-demo");
+    assert_eq!(body["apply"], false);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vector_health_policy_denial_returns_forbidden() -> Result<()> {
+    let temp_dir = TempDir::new().context("create policy temp dir")?;
+    let policy_path = temp_dir.path().join("policy.json");
+    std::fs::write(&policy_path, "{}").context("write policy file")?;
+
+    let server = TestServer::spawn(Some(&policy_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/vector-health"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "invalid_sample_limit": 5
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "policy_denied");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn malformed_json_returns_invalid_json_error() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("x-loong-principal", "operator")
+        .header("content-type", "application/json")
+        .body("{\"namespace\":")
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "invalid_json");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recall_rejects_invalid_weights_over_http() -> Result<()> {
+    let server = TestServer::spawn(None).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/recall"))
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "query": "rust sqlite",
+            "limit": 3,
+            "lexical_weight": 0.0,
+            "vector_weight": 0.0
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "validation_failed");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn healthz_reports_readiness_failure_for_unopenable_db_path() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let db_path = temp_dir.path().join("missing").join("loong-memory.db");
+    let server = TestServer::spawn_with_db_path(temp_dir, db_path, None).await?;
+
+    let response = server.client.get(server.url("/healthz")).send().await?;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "internal_error");
     Ok(())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,9 +91,12 @@ Phase 2 now starts with a minimal HTTP JSON daemon:
 
 - `GET /healthz`
 - `POST /v1/memories`
+- `DELETE /v1/memories`
 - `POST /v1/memories/get`
 - `POST /v1/recall`
 - `POST /v1/audit`
+- `POST /v1/vector-health`
+- `POST /v1/vector-repair`
 
 Transport behavior:
 
@@ -180,8 +183,9 @@ Current integration tests validate:
 - vector repair workflow (`dry-run` planning + transactional `apply`)
 - principal+namespace scoped static policy behavior
 - audit SQLite persistence/filter/limit/error behavior
-- daemon health, principal enforcement, put/get roundtrip, recall, policy deny,
-  and audit-read behavior over HTTP
+- daemon health, readiness failure, principal enforcement, malformed JSON,
+  validation failures, delete, recall, audit, vector health/repair, and deny
+  behavior over HTTP
 
 Quality gates:
 

--- a/docs/plans/2026-03-15-loong-memoryd-transport-hardening-design.md
+++ b/docs/plans/2026-03-15-loong-memoryd-transport-hardening-design.md
@@ -1,0 +1,265 @@
+# loong-memoryd Transport Hardening Design
+
+Date: 2026-03-15
+Owner: chumyin
+Issue: #6
+
+## 1. Context
+
+`loong-memoryd` now provides the first real Phase 2 daemon surface:
+
+- `GET /healthz`
+- `POST /v1/memories`
+- `POST /v1/memories/get`
+- `POST /v1/recall`
+- `POST /v1/audit`
+
+The transport layer already preserves the core engine's validation, policy, and
+audit semantics by constructing a fresh `MemoryEngine` per request inside
+`spawn_blocking`. The next delivery gap is no longer "is there a daemon at
+all?", but "does the daemon expose enough of the engine's operational surface to
+be credible for real service use?"
+
+## 2. Problem Statement
+
+The engine and CLI already support:
+
+- delete
+- vector health diagnostics
+- vector repair planning and apply mode
+- detailed validation and policy failures
+
+The daemon does not yet expose those capabilities over HTTP, and its service
+tests still focus mainly on happy paths. That leaves a gap between the shipped
+daemon surface and the already-delivered operational capabilities underneath it.
+
+## 3. Goals
+
+1. Add HTTP delete support to `loong-memoryd`.
+2. Add HTTP `vector_health` support to `loong-memoryd`.
+3. Add HTTP `vector_repair` support to `loong-memoryd`.
+4. Preserve existing engine policy and audit semantics for all new routes.
+5. Add service-level negative-path regression tests for malformed JSON and
+   validation failures.
+6. Add a readiness-failure regression test for `/healthz`.
+7. Update docs and research notes to reflect the broader daemon surface.
+
+## 4. Non-Goals
+
+- gRPC transport
+- SDK clients
+- auth provider integration
+- policy hot reload
+- shared engine pooling or latency optimization
+- daemon-side metrics/tracing export
+
+## 5. Approaches Considered
+
+### Approach A: Negative Tests Only
+
+Keep the route surface unchanged and only add malformed-input and readiness
+failure coverage.
+
+Pros:
+
+- smallest code change
+- strengthens transport error confidence
+
+Cons:
+
+- still leaves delete and maintenance capabilities missing from the daemon
+- keeps the transport surface visibly behind the CLI
+
+### Approach B: Transport Hardening Slice
+
+Add delete + maintenance routes and pair them with stronger negative-path
+coverage.
+
+Pros:
+
+- closes the most obvious daemon capability gaps
+- keeps scope within the current HTTP design
+- reuses existing engine operations with low architectural risk
+- materially improves Phase 2 completeness
+
+Cons:
+
+- touches both handlers and integration tests
+- expands docs again immediately after the first daemon release
+
+### Approach C: Jump to gRPC / SDK Work
+
+Leave the current daemon shape as-is and move to new protocol or client layers.
+
+Pros:
+
+- advances later Phase 2 roadmap items
+
+Cons:
+
+- compounds an incomplete service surface instead of stabilizing it
+- risks freezing awkward API gaps into future client contracts
+
+## 6. Chosen Approach
+
+Approach B.
+
+The best next move is to harden the existing daemon before layering more
+transport or client abstractions on top of it.
+
+## 7. Proposed Design
+
+## 7.1 Route Additions
+
+Add the following endpoints:
+
+- `DELETE /v1/memories`
+- `POST /v1/vector-health`
+- `POST /v1/vector-repair`
+
+All three remain protected by `x-loong-principal`.
+
+## 7.2 Delete Transport Shape
+
+Use:
+
+- `DELETE /v1/memories`
+
+Request body:
+
+```json
+{
+  "namespace": "agent-demo",
+  "external_id": "profile"
+}
+```
+
+The handler maps directly to `MemoryDeleteRequest`.
+
+Why this shape:
+
+- keeps route naming consistent with the existing `POST /v1/memories`
+- preserves current selector semantics (`id` XOR `external_id`)
+- avoids premature resource-URL design churn
+
+Success response:
+
+```json
+{ "ok": true }
+```
+
+## 7.3 Maintenance Transport Shape
+
+`vector_health` request body:
+
+```json
+{
+  "namespace": "agent-demo",
+  "invalid_sample_limit": 20
+}
+```
+
+`vector_repair` request body:
+
+```json
+{
+  "namespace": "agent-demo",
+  "issue_sample_limit": 20,
+  "apply": false
+}
+```
+
+These map directly onto the existing engine methods:
+
+- `MemoryEngine::vector_health`
+- `MemoryEngine::vector_repair`
+
+This is important because the engine already owns the correct policy and audit
+behavior:
+
+- `vector_health` is gated by `Action::AuditRead`
+- `vector_repair` is gated by `Action::Repair`
+
+## 7.4 Error Semantics
+
+Retain the current structured error envelope and strengthen tests around it.
+
+Important negative-path cases to pin at the HTTP layer:
+
+- malformed JSON -> `400`, `invalid_json`
+- invalid recall weights -> `400`, `validation_failed`
+- invalid delete selector (`id` + `external_id`) -> `400`, `validation_failed`
+- missing principal -> `401`, `missing_principal`
+- policy denial -> `403`, `policy_denied`
+- readiness failure -> `500`, `internal_error`
+
+The core engine already generates most validation and policy failures; the goal
+here is to prove the transport preserves them.
+
+## 7.5 Readiness Failure Test
+
+`/healthz` should stay honest. Add a test that starts the daemon with a database
+path nested under a non-existent directory so SQLite open fails at health-check
+time.
+
+Expected behavior:
+
+- server starts
+- `GET /healthz` returns `500`
+- response uses the structured error envelope
+
+This is preferable to trying to force the daemon to fail at startup, because it
+tests the documented readiness semantics directly.
+
+## 7.6 Test Strategy
+
+Add or extend HTTP integration tests for:
+
+- `DELETE /v1/memories` happy path
+- invalid delete selector
+- `POST /v1/vector-health` happy path
+- `POST /v1/vector-repair` dry-run happy path
+- policy denial for at least one maintenance route
+- malformed JSON on a protected endpoint
+- invalid recall-weight validation
+- `/healthz` readiness failure
+
+Keep tests end to end through the live HTTP server helper.
+
+## 7.7 Documentation Updates
+
+Update:
+
+- `README.md`
+- `docs/architecture.md`
+- `docs/roadmap.md` if needed only for wording clarity
+- `docs/research/phase2-service-evaluation-2026-03-15.md`
+
+The README should show the expanded daemon route set and example requests for
+delete and maintenance operations.
+
+## 8. Risks and Mitigations
+
+Risk: HTTP delete with JSON body is less canonical than path-based REST design.
+
+Mitigation:
+
+- keep the route intentionally minimal and document it as part of the Phase 2
+  bootstrap surface
+- preserve the engine's established selector contract instead of inventing a
+  more rigid URL layout too early
+
+Risk: maintenance routes over-expose privileged functionality.
+
+Mitigation:
+
+- route only through existing engine methods
+- rely on the same policy and audit semantics already exercised by the CLI
+- add deny-path tests at the service layer
+
+Risk: transport error mapping drifts from current behavior.
+
+Mitigation:
+
+- pin negative cases with integration tests instead of only unit-level mapping
+  logic

--- a/docs/plans/2026-03-15-loong-memoryd-transport-hardening.md
+++ b/docs/plans/2026-03-15-loong-memoryd-transport-hardening.md
@@ -1,0 +1,231 @@
+# loong-memoryd Transport Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Broaden `loong-memoryd` so it exposes delete and maintenance operations over HTTP and pins service-level negative-path behavior with end-to-end tests.
+
+**Architecture:** Extend the existing Axum router and per-request `MemoryEngine` execution model. Reuse current engine request/response types where possible, add small transport DTOs for maintenance routes, and harden the HTTP layer with integration tests for malformed JSON, validation failures, and readiness failure.
+
+**Tech Stack:** Rust, `axum`, `tokio`, `reqwest`, existing `loong-memory-core`
+
+---
+
+### Task 1: Add failing HTTP integration tests for the new transport slice
+
+**Files:**
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- delete over HTTP
+- vector health over HTTP
+- vector repair dry-run over HTTP
+- malformed JSON returns `invalid_json`
+- invalid recall weights return `validation_failed`
+- invalid delete selector returns `validation_failed`
+- `/healthz` readiness failure returns `500`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd`
+Expected: FAIL because these routes and behaviors are not all implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Do not implement yet. This task ends with failing tests in place.
+
+**Step 4: Run test to verify it passes**
+
+Not applicable in this task.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "test: add failing loong-memoryd transport hardening cases"
+```
+
+### Task 2: Implement delete transport support
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Use the new tests from Task 1 for:
+
+- delete success
+- invalid delete selector
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd delete`
+Expected: FAIL because `DELETE /v1/memories` is not implemented.
+
+**Step 3: Write minimal implementation**
+
+- register `DELETE /v1/memories`
+- accept `MemoryDeleteRequest` as JSON body
+- route through `MemoryEngine::delete`
+- return `{ "ok": true }` on success
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd delete`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: add loong-memoryd delete endpoint"
+```
+
+### Task 3: Implement vector health and vector repair HTTP routes
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Use the new tests from Task 1 for:
+
+- vector health success
+- vector repair dry-run success
+- maintenance-route policy denial
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd vector`
+Expected: FAIL because the maintenance routes are not implemented.
+
+**Step 3: Write minimal implementation**
+
+- add request DTOs for maintenance routes
+- register `POST /v1/vector-health`
+- register `POST /v1/vector-repair`
+- route through the engine methods without bypassing policy or audit logic
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd vector`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: add loong-memoryd maintenance endpoints"
+```
+
+### Task 4: Harden negative-path transport behavior
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Use the new tests from Task 1 for:
+
+- malformed JSON
+- invalid recall weights
+- readiness failure on `/healthz`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd invalid_json`
+Run: `cargo test -p loong-memoryd healthz`
+Expected: FAIL until transport behavior is fully pinned.
+
+**Step 3: Write minimal implementation**
+
+- add any missing helpers required for testability
+- ensure readiness failure uses the structured error envelope
+- preserve existing `invalid_json` and validation error mapping
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "test: harden loong-memoryd negative-path coverage"
+```
+
+### Task 5: Update docs and research notes
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/research/phase2-service-evaluation-2026-03-15.md`
+
+**Step 1: Write the failing test**
+
+No product test. This task updates documentation and evidence.
+
+**Step 2: Run test to verify it fails**
+
+Not applicable.
+
+**Step 3: Write minimal implementation**
+
+- document the expanded route set
+- add example delete and maintenance requests
+- update the research note with the broadened service surface and new negative-path verification
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd`
+Expected: PASS with docs updated alongside the implementation.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/architecture.md docs/research/phase2-service-evaluation-2026-03-15.md
+git commit -m "docs: update loong-memoryd transport coverage"
+```
+
+### Task 6: Run full verification and prepare GitHub delivery
+
+**Files:**
+- No additional product files required
+
+**Step 1: Write the failing test**
+
+No new test.
+
+**Step 2: Run test to verify it fails**
+
+Not applicable.
+
+**Step 3: Write minimal implementation**
+
+- inspect `git status --short`
+- inspect `git diff --cached --name-only`
+- inspect `git diff --cached`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat: harden loong-memoryd transport surface"
+```

--- a/docs/research/phase2-service-evaluation-2026-03-15.md
+++ b/docs/research/phase2-service-evaluation-2026-03-15.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-This round delivers the first Phase 2 runtime boundary for `loong-memory`:
-`loong-memoryd`, a standalone HTTP JSON daemon that reuses the existing engine,
-policy, and audit contracts.
+This Phase 2 work now delivers both the initial daemon bootstrap and the first
+transport-hardening pass for `loong-memoryd`, the standalone HTTP JSON service
+that reuses the existing engine, policy, and audit contracts.
 
 ## Why This Was the Right Next Step
 
@@ -51,11 +51,16 @@ reactor.
 - `crates/loong-memoryd`
 - `GET /healthz`
 - `POST /v1/memories`
+- `DELETE /v1/memories`
 - `POST /v1/memories/get`
 - `POST /v1/recall`
 - `POST /v1/audit`
+- `POST /v1/vector-health`
+- `POST /v1/vector-repair`
 - structured HTTP error mapping
 - startup config via `--db`, `--listen-addr`, `--policy-file`
+- service-level negative-path coverage for malformed JSON, validation failure,
+  and readiness failure
 - updated repository docs
 
 ## Verification
@@ -69,17 +74,23 @@ Local verification passed:
 Covered HTTP integration behaviors:
 
 - health endpoint does not require a principal
+- health endpoint reports readiness failure when the configured DB path cannot
+  be opened
 - protected routes reject missing principal headers
+- malformed JSON returns structured `invalid_json`
 - put/get roundtrip succeeds over the daemon surface
+- delete removes records over HTTP and preserves selector validation
 - recall returns relevant results over HTTP
+- invalid recall-weight requests return structured validation failures
 - static policy denial returns `403`
 - audit read returns namespace history without self-pollution
+- vector health and vector repair are available over HTTP
+- maintenance-route policy denial is preserved over HTTP
 
 ## Residual Gaps
 
 This is a bootstrap slice, not the full Phase 2 end state. Still missing:
 
-- delete and maintenance HTTP routes
 - gRPC transport
 - SDK clients
 - metrics/tracing export
@@ -88,6 +99,7 @@ This is a bootstrap slice, not the full Phase 2 end state. Still missing:
 ## Outcome
 
 The repository now has a credible Phase 2 starting point: a real daemon
-boundary, transport-level identity propagation, structured health checks, and
-end-to-end service tests. That materially improves delivery completeness over a
-CLI-only Phase 1 story.
+boundary, transport-level identity propagation, structured health checks,
+maintenance-route coverage, and end-to-end service tests for both happy and
+negative paths. That materially improves delivery completeness over a CLI-only
+Phase 1 story.


### PR DESCRIPTION
## Summary
- broaden `loong-memoryd` with HTTP delete, vector-health, and vector-repair endpoints while preserving existing engine policy and audit semantics
- harden the daemon's service-level regression coverage with delete, malformed JSON, validation-failure, policy-denial, and readiness-failure integration tests
- update the README, architecture notes, and Phase 2 research note so the documented daemon surface matches the shipped routes and verification story

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DELETE /v1/memories endpoint for removing memory records.
  * Added POST /v1/vector-health endpoint for diagnostics and health checks.
  * Added POST /v1/vector-repair endpoint for maintenance operations.

* **Improvements**
  * Enhanced error handling with structured validation responses for invalid inputs and readiness failures.

* **Documentation**
  * Updated README with endpoint usage examples and curl commands demonstrating all three new routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->