### PR TITLE
Add a real auth envelope to loong-memoryd

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ minimal daemon surface:
   - `POST /v1/vector-health`
   - `POST /v1/vector-repair`
   - per-request `MemoryEngine` construction on blocking workers
-  - transport-level principal envelope via `x-loong-principal`
+  - trusted-header mode via `x-loong-principal` for local operator workflows
+  - optional static bearer-token auth via `--auth-file <path>`
+  - `/healthz` reports both `policy_mode` and `auth_mode`
 
 ## Repository Layout
 
@@ -44,6 +46,7 @@ minimal daemon surface:
 - `crates/loong-memory-cli`: command-line operational entrypoint.
 - `crates/loong-memoryd`: standalone Phase 2 HTTP daemon.
 - `docs/architecture.md`: architecture and data model details.
+- `docs/examples/static-auth.example.json`: example bearer-token auth mapping for `loong-memoryd`.
 - `docs/examples/static-policy.example.json`: example JSON policy file for CLI enforcement.
 - `docs/research/onecontext-reverse-engineering.md`: onecontext implementation analysis and extracted design lessons.
 - `docs/research/phase1-evaluation-2026-03-08.md`: deep evaluation, optimization decisions, and verification results.
@@ -74,7 +77,10 @@ cargo run -p loong-memory-cli -- init --db ./loong-memory.db
 # 3) optionally enforce policy with a JSON config
 cp docs/examples/static-policy.example.json ./policy.json
 
-# 4) write memory
+# 4) optionally enable static bearer-token auth for the daemon
+cp docs/examples/static-auth.example.json ./auth.json
+
+# 5) write memory
 cargo run -p loong-memory-cli -- --policy-file ./policy.json put \
   --db ./loong-memory.db \
   --namespace agent-demo \
@@ -83,14 +89,14 @@ cargo run -p loong-memory-cli -- --policy-file ./policy.json put \
   --metadata '{"source":"seed"}' \
   --principal operator
 
-# 5) read memory
+# 6) read memory
 cargo run -p loong-memory-cli -- --policy-file ./policy.json get \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --external-id profile \
   --principal operator
 
-# 6) recall
+# 7) recall
 cargo run -p loong-memory-cli -- --policy-file ./policy.json recall \
   --db ./loong-memory.db \
   --namespace agent-demo \
@@ -98,40 +104,41 @@ cargo run -p loong-memory-cli -- --policy-file ./policy.json recall \
   --limit 3 \
   --principal operator
 
-# 7) audit trail (namespace + principal are required)
+# 8) audit trail (namespace + principal are required)
 cargo run -p loong-memory-cli -- --policy-file ./policy.json audit \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --limit 20 \
   --principal operator
 
-# 8) vector health diagnostics
+# 9) vector health diagnostics
 cargo run -p loong-memory-cli -- --policy-file ./policy.json vector-health \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --invalid-sample-limit 20 \
   --principal operator
 
-# 9) vector repair (dry-run by default, add --apply to write changes)
+# 10) vector repair (dry-run by default, add --apply to write changes)
 cargo run -p loong-memory-cli -- --policy-file ./policy.json vector-repair \
   --db ./loong-memory.db \
   --namespace agent-demo \
   --issue-sample-limit 20 \
   --principal operator
 
-# 10) start the daemon
+# 11) start the daemon in static-token mode
 cargo run -p loong-memoryd -- \
   --db ./loong-memory.db \
   --listen-addr 127.0.0.1:3000 \
-  --policy-file ./policy.json
+  --policy-file ./policy.json \
+  --auth-file ./auth.json
 
-# 11) health check (no principal required)
+# 12) health check (no authentication required)
 curl http://127.0.0.1:3000/healthz
 
-# 12) daemon write
+# 13) daemon write
 curl -X POST http://127.0.0.1:3000/v1/memories \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "external_id": "profile",
@@ -139,53 +146,56 @@ curl -X POST http://127.0.0.1:3000/v1/memories \
     "metadata": {"source": "daemon"}
   }'
 
-# 13) daemon recall
+# 14) daemon recall
 curl -X POST http://127.0.0.1:3000/v1/recall \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "query": "rust sqlite",
     "limit": 3
   }'
 
-# 14) daemon audit read
+# 15) daemon audit read
 curl -X POST http://127.0.0.1:3000/v1/audit \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "limit": 20
   }'
 
-# 15) daemon delete
+# 16) daemon delete
 curl -X DELETE http://127.0.0.1:3000/v1/memories \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "external_id": "profile"
   }'
 
-# 16) daemon vector health
+# 17) daemon vector health
 curl -X POST http://127.0.0.1:3000/v1/vector-health \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "invalid_sample_limit": 20
   }'
 
-# 17) daemon vector repair dry-run
+# 18) daemon vector repair dry-run
 curl -X POST http://127.0.0.1:3000/v1/vector-repair \
   -H 'content-type: application/json' \
-  -H 'x-loong-principal: operator' \
+  -H 'authorization: Bearer operator-secret' \
   -d '{
     "namespace": "agent-demo",
     "issue_sample_limit": 20,
     "apply": false
   }'
 ```
+
+If you omit `--auth-file`, `loong-memoryd` stays in trusted-header mode and
+protected routes continue to require `x-loong-principal`.
 
 ## Verification Gates
 
@@ -204,7 +214,11 @@ cargo test --workspace
 - `loong-memoryd` also defaults to `AllowAllPolicy` when `--policy-file` is omitted.
 - Policy is checked before store access.
 - Static JSON policy files can grant namespace-level and principal+namespace actions.
-- HTTP service routes require `x-loong-principal` on protected operations.
+- `loong-memoryd` uses trusted-header mode when `--auth-file` is omitted.
+- `loong-memoryd` uses static-token mode when `--auth-file` is present and derives
+  the effective principal from `Authorization: Bearer <token>`.
+- Static-token mode ignores caller-supplied `x-loong-principal` for identity derivation.
+- `/healthz` reports `policy_mode` and `auth_mode` without exposing secrets.
 - All actions emit auditable events (allow/deny + operation detail).
 - Audit reads are policy-gated and returned history excludes self-generated audit-read events.
 - Audit persistence surfaces write failures instead of silently dropping events.

--- a/crates/loong-memoryd/src/lib.rs
+++ b/crates/loong-memoryd/src/lib.rs
@@ -1,13 +1,14 @@
 #![forbid(unsafe_code)]
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use axum::{
     extract::{rejection::JsonRejection, State},
-    http::{HeaderMap, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
@@ -28,13 +29,15 @@ pub const PRINCIPAL_HEADER: &str = "x-loong-principal";
 pub struct ServiceConfig {
     db_path: PathBuf,
     policy_file: Option<PathBuf>,
+    auth_file: Option<PathBuf>,
 }
 
 impl ServiceConfig {
-    pub fn new(db_path: PathBuf, policy_file: Option<PathBuf>) -> Self {
+    pub fn new(db_path: PathBuf, policy_file: Option<PathBuf>, auth_file: Option<PathBuf>) -> Self {
         Self {
             db_path,
             policy_file,
+            auth_file,
         }
     }
 
@@ -45,6 +48,10 @@ impl ServiceConfig {
     pub fn policy_file(&self) -> Option<&Path> {
         self.policy_file.as_deref()
     }
+
+    pub fn auth_file(&self) -> Option<&Path> {
+        self.auth_file.as_deref()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -54,23 +61,79 @@ pub enum PolicyMode {
     Static,
 }
 
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMode {
+    TrustedHeader,
+    StaticToken,
+}
+
+#[derive(Debug, Deserialize)]
+struct StaticAuthConfig {
+    #[serde(default)]
+    tokens: Vec<StaticTokenConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StaticTokenConfig {
+    token: String,
+    principal: String,
+}
+
+#[derive(Clone)]
+enum Authenticator {
+    TrustedHeader,
+    StaticToken {
+        token_to_principal: Arc<HashMap<String, String>>,
+    },
+}
+
+impl Authenticator {
+    fn mode(&self) -> AuthMode {
+        match self {
+            Self::TrustedHeader => AuthMode::TrustedHeader,
+            Self::StaticToken { .. } => AuthMode::StaticToken,
+        }
+    }
+
+    fn authenticate(&self, headers: &HeaderMap) -> Result<String, ApiError> {
+        match self {
+            Self::TrustedHeader => extract_trusted_header_principal(headers),
+            Self::StaticToken { token_to_principal } => {
+                let token = extract_bearer_token(headers)?;
+                token_to_principal
+                    .get(token)
+                    .cloned()
+                    .ok_or_else(|| ApiError::invalid_authentication("invalid bearer token"))
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ServiceState {
     db_path: PathBuf,
     policy: Arc<dyn PolicyEngine>,
     embedder: Arc<dyn EmbeddingProvider>,
     policy_mode: PolicyMode,
+    authenticator: Authenticator,
 }
 
 impl ServiceState {
     pub fn from_config(config: &ServiceConfig) -> Result<Self> {
         let (policy, policy_mode) = load_policy(config.policy_file())?;
+        let authenticator = load_authenticator(config.auth_file())?;
         Ok(Self {
             db_path: config.db_path().to_path_buf(),
             policy,
             embedder: Arc::new(DeterministicHashEmbedder::default()),
             policy_mode,
+            authenticator,
         })
+    }
+
+    pub fn auth_mode(&self) -> AuthMode {
+        self.authenticator.mode()
     }
 }
 
@@ -115,6 +178,7 @@ struct HealthResponse {
     service: &'static str,
     db: String,
     policy_mode: PolicyMode,
+    auth_mode: AuthMode,
 }
 
 #[derive(Debug, Serialize)]
@@ -170,8 +234,16 @@ impl ApiError {
         Self::new(StatusCode::BAD_REQUEST, "validation_failed", message)
     }
 
-    fn unauthorized(message: impl Into<String>) -> Self {
+    fn missing_principal(message: impl Into<String>) -> Self {
         Self::new(StatusCode::UNAUTHORIZED, "missing_principal", message)
+    }
+
+    fn missing_authentication(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, "missing_authentication", message)
+    }
+
+    fn invalid_authentication(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, "invalid_authentication", message)
     }
 
     fn internal(message: impl Into<String>) -> Self {
@@ -272,6 +344,7 @@ async fn health(State(state): State<ServiceState>) -> Result<Json<HealthResponse
         service: "loong-memoryd",
         db: state.db_path.display().to_string(),
         policy_mode: state.policy_mode,
+        auth_mode: state.auth_mode(),
     }))
 }
 
@@ -280,7 +353,7 @@ async fn put_memory(
     headers: HeaderMap,
     body: Result<Json<MemoryPutRequest>, JsonRejection>,
 ) -> Result<Json<loong_memory_core::MemoryRecord>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let record = with_engine(state, principal, move |engine, ctx| engine.put(&ctx, &req)).await?;
     Ok(Json(record))
@@ -291,7 +364,7 @@ async fn get_memory(
     headers: HeaderMap,
     body: Result<Json<MemoryGetRequest>, JsonRejection>,
 ) -> Result<Json<loong_memory_core::MemoryRecord>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let record = with_engine(state, principal, move |engine, ctx| engine.get(&ctx, &req)).await?;
     Ok(Json(record))
@@ -302,7 +375,7 @@ async fn delete_memory(
     headers: HeaderMap,
     body: Result<Json<MemoryDeleteRequest>, JsonRejection>,
 ) -> Result<Json<OkBody>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     with_engine(state, principal, move |engine, ctx| {
         engine.delete(&ctx, &req)
@@ -316,7 +389,7 @@ async fn recall(
     headers: HeaderMap,
     body: Result<Json<RecallRequestBody>, JsonRejection>,
 ) -> Result<Json<CountEnvelope<HitsBody>>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let weights = normalize_weights(req.lexical_weight, req.vector_weight)?;
     let request = RecallRequest {
@@ -340,7 +413,7 @@ async fn audit(
     headers: HeaderMap,
     body: Result<Json<AuditRequestBody>, JsonRejection>,
 ) -> Result<Json<CountEnvelope<AuditEventsBody>>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let events = with_engine(state, principal, move |engine, ctx| {
         engine.audit_events(&ctx, &req.namespace, req.limit)
@@ -357,7 +430,7 @@ async fn vector_health(
     headers: HeaderMap,
     body: Result<Json<VectorHealthRequestBody>, JsonRejection>,
 ) -> Result<Json<loong_memory_core::VectorHealthReport>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let report = with_engine(state, principal, move |engine, ctx| {
         engine.vector_health(&ctx, &req.namespace, req.invalid_sample_limit)
@@ -371,7 +444,7 @@ async fn vector_repair(
     headers: HeaderMap,
     body: Result<Json<VectorRepairRequestBody>, JsonRejection>,
 ) -> Result<Json<loong_memory_core::VectorRepairReport>, ApiError> {
-    let principal = extract_principal(&headers)?;
+    let principal = state.authenticator.authenticate(&headers)?;
     let Json(req) = body.map_err(ApiError::from)?;
     let report = with_engine(state, principal, move |engine, ctx| {
         engine.vector_repair(&ctx, &req.namespace, req.issue_sample_limit, req.apply)
@@ -404,23 +477,52 @@ fn default_issue_sample_limit() -> usize {
     20
 }
 
-fn extract_principal(headers: &HeaderMap) -> Result<String, ApiError> {
+fn extract_trusted_header_principal(headers: &HeaderMap) -> Result<String, ApiError> {
     let Some(value) = headers.get(PRINCIPAL_HEADER) else {
-        return Err(ApiError::unauthorized(format!(
+        return Err(ApiError::missing_principal(format!(
             "missing required header {PRINCIPAL_HEADER}"
         )));
     };
     let principal = value
         .to_str()
-        .map_err(|_| ApiError::unauthorized(format!("invalid header {PRINCIPAL_HEADER}")))?
+        .map_err(|_| ApiError::missing_principal(format!("invalid header {PRINCIPAL_HEADER}")))?
         .trim()
         .to_owned();
     if principal.is_empty() {
-        return Err(ApiError::unauthorized(format!(
+        return Err(ApiError::missing_principal(format!(
             "missing required header {PRINCIPAL_HEADER}"
         )));
     }
     Ok(principal)
+}
+
+fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
+    let Some(value) = headers.get(header::AUTHORIZATION) else {
+        return Err(ApiError::missing_authentication(
+            "missing required header authorization",
+        ));
+    };
+    let authorization = value
+        .to_str()
+        .map_err(|_| ApiError::invalid_authentication("invalid authorization header"))?
+        .trim();
+    let mut parts = authorization.split_whitespace();
+    let Some(scheme) = parts.next() else {
+        return Err(ApiError::invalid_authentication(
+            "expected Authorization: Bearer <token>",
+        ));
+    };
+    let Some(token) = parts.next() else {
+        return Err(ApiError::invalid_authentication(
+            "expected Authorization: Bearer <token>",
+        ));
+    };
+    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
+        return Err(ApiError::invalid_authentication(
+            "expected Authorization: Bearer <token>",
+        ));
+    }
+    Ok(token)
 }
 
 fn normalize_weights(lexical: f32, vector: f32) -> Result<ScoreWeights, ApiError> {
@@ -478,5 +580,48 @@ fn load_policy(policy_file: Option<&Path>) -> Result<(Arc<dyn PolicyEngine>, Pol
             ))
         }
         None => Ok((Arc::new(AllowAllPolicy), PolicyMode::AllowAll)),
+    }
+}
+
+fn load_authenticator(auth_file: Option<&Path>) -> Result<Authenticator> {
+    match auth_file {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .with_context(|| format!("read auth file {}", path.display()))?;
+            let config: StaticAuthConfig = serde_json::from_str(&raw)
+                .with_context(|| format!("parse auth file {}", path.display()))?;
+            let mut token_to_principal = HashMap::new();
+            for token_config in config.tokens {
+                let token = token_config.token.trim();
+                if token.is_empty() {
+                    bail!("auth file {} contains an empty token", path.display());
+                }
+                if token.chars().any(char::is_whitespace) {
+                    bail!(
+                        "auth file {} contains token entries with whitespace",
+                        path.display()
+                    );
+                }
+
+                let principal = token_config.principal.trim();
+                if principal.is_empty() {
+                    bail!("auth file {} contains an empty principal", path.display());
+                }
+                if token_to_principal
+                    .insert(token.to_owned(), principal.to_owned())
+                    .is_some()
+                {
+                    bail!(
+                        "auth file {} contains duplicate token entries",
+                        path.display()
+                    );
+                }
+            }
+
+            Ok(Authenticator::StaticToken {
+                token_to_principal: Arc::new(token_to_principal),
+            })
+        }
+        None => Ok(Authenticator::TrustedHeader),
     }
 }

--- a/crates/loong-memoryd/src/main.rs
+++ b/crates/loong-memoryd/src/main.rs
@@ -18,6 +18,8 @@ struct Cli {
     listen_addr: SocketAddr,
     #[arg(long)]
     policy_file: Option<PathBuf>,
+    #[arg(long)]
+    auth_file: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -26,7 +28,11 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
 
     let cli = Cli::parse();
-    let config = ServiceConfig::new(cli.db.clone(), cli.policy_file.clone());
+    let config = ServiceConfig::new(
+        cli.db.clone(),
+        cli.policy_file.clone(),
+        cli.auth_file.clone(),
+    );
     let state = ServiceState::from_config(&config).context("build loong-memoryd state")?;
     let listener = TcpListener::bind(cli.listen_addr)
         .await

--- a/crates/loong-memoryd/tests/auth_config_integration.rs
+++ b/crates/loong-memoryd/tests/auth_config_integration.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use loong_memoryd::{ServiceConfig, ServiceState};
+use serde_json::json;
+use tempfile::TempDir;
+
+#[test]
+fn service_state_rejects_duplicate_auth_tokens() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let auth_path = temp_dir.path().join("auth.json");
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "shared-secret",
+                    "principal": "operator"
+                },
+                {
+                    "token": "shared-secret",
+                    "principal": "viewer"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let config = ServiceConfig::new(
+        temp_dir.path().join("loong-memory.db"),
+        None,
+        Some(PathBuf::from(&auth_path)),
+    );
+    let err = match ServiceState::from_config(&config) {
+        Ok(_) => panic!("duplicate token should fail"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("duplicate token entries"));
+    Ok(())
+}
+
+#[test]
+fn service_state_rejects_empty_auth_principal() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let auth_path = temp_dir.path().join("auth.json");
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "operator-secret",
+                    "principal": "   "
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let config = ServiceConfig::new(
+        temp_dir.path().join("loong-memory.db"),
+        None,
+        Some(PathBuf::from(&auth_path)),
+    );
+    let err = match ServiceState::from_config(&config) {
+        Ok(_) => panic!("empty principal should fail"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("empty principal"));
+    Ok(())
+}

--- a/crates/loong-memoryd/tests/http_service_integration.rs
+++ b/crates/loong-memoryd/tests/http_service_integration.rs
@@ -34,7 +34,7 @@ impl TestServer {
         temp_dir: TempDir,
         db_path: PathBuf,
         policy_file: Option<&Path>,
-        _auth_file: Option<&Path>,
+        auth_file: Option<&Path>,
     ) -> Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -42,7 +42,11 @@ impl TestServer {
         let address = listener.local_addr().context("read listener address")?;
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let config = ServiceConfig::new(db_path, policy_file.map(PathBuf::from));
+        let config = ServiceConfig::new(
+            db_path,
+            policy_file.map(PathBuf::from),
+            auth_file.map(PathBuf::from),
+        );
         let state = ServiceState::from_config(&config)?;
 
         let join_handle = tokio::spawn(async move {
@@ -503,7 +507,9 @@ async fn bearer_token_allows_put_without_principal_header() -> Result<()> {
     .context("write auth file")?;
 
     let db_path = temp_dir.path().join("loong-memory.db");
-    let server = TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path)).await?;
+    let server =
+        TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path))
+            .await?;
 
     let response = server
         .client
@@ -632,7 +638,9 @@ async fn static_token_mode_ignores_spoofed_principal_header() -> Result<()> {
     .context("write auth file")?;
 
     let db_path = temp_dir.path().join("loong-memory.db");
-    let server = TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path)).await?;
+    let server =
+        TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path))
+            .await?;
 
     let response = server
         .client

--- a/crates/loong-memoryd/tests/http_service_integration.rs
+++ b/crates/loong-memoryd/tests/http_service_integration.rs
@@ -19,13 +19,22 @@ impl TestServer {
     async fn spawn(policy_file: Option<&Path>) -> Result<Self> {
         let temp_dir = TempDir::new().context("create temp dir")?;
         let db_path = temp_dir.path().join("loong-memory.db");
-        Self::spawn_with_db_path(temp_dir, db_path, policy_file).await
+        Self::spawn_with_security(temp_dir, db_path, policy_file, None).await
     }
 
     async fn spawn_with_db_path(
         temp_dir: TempDir,
         db_path: PathBuf,
         policy_file: Option<&Path>,
+    ) -> Result<Self> {
+        Self::spawn_with_security(temp_dir, db_path, policy_file, None).await
+    }
+
+    async fn spawn_with_security(
+        temp_dir: TempDir,
+        db_path: PathBuf,
+        policy_file: Option<&Path>,
+        _auth_file: Option<&Path>,
     ) -> Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -79,6 +88,7 @@ async fn healthz_returns_ok_without_principal() -> Result<()> {
     assert_eq!(body["status"], "ok");
     assert_eq!(body["service"], "loong-memoryd");
     assert_eq!(body["policy_mode"], "allow_all");
+    assert_eq!(body["auth_mode"], "trusted_header");
     Ok(())
 }
 
@@ -457,5 +467,217 @@ async fn healthz_reports_readiness_failure_for_unopenable_db_path() -> Result<()
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body: Value = response.json().await?;
     assert_eq!(body["error"]["code"], "internal_error");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bearer_token_allows_put_without_principal_header() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let policy_path = temp_dir.path().join("policy.json");
+    let auth_path = temp_dir.path().join("auth.json");
+
+    std::fs::write(
+        &policy_path,
+        serde_json::to_string_pretty(&json!({
+            "principal_namespace_actions": [
+                {
+                    "principal": "operator",
+                    "namespace": "agent-demo",
+                    "actions": ["put", "get", "recall", "delete", "audit_read", "repair"]
+                }
+            ]
+        }))?,
+    )
+    .context("write policy file")?;
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "operator-secret",
+                    "principal": "operator"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let db_path = temp_dir.path().join("loong-memory.db");
+    let server = TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("authorization", "Bearer operator-secret")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "auth-test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn static_token_mode_rejects_missing_bearer_token() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let auth_path = temp_dir.path().join("auth.json");
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "operator-secret",
+                    "principal": "operator"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let db_path = temp_dir.path().join("loong-memory.db");
+    let server = TestServer::spawn_with_security(temp_dir, db_path, None, Some(&auth_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "auth-test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "missing_authentication");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn static_token_mode_rejects_invalid_bearer_token() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let auth_path = temp_dir.path().join("auth.json");
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "operator-secret",
+                    "principal": "operator"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let db_path = temp_dir.path().join("loong-memory.db");
+    let server = TestServer::spawn_with_security(temp_dir, db_path, None, Some(&auth_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("authorization", "Bearer wrong-secret")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "auth-test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "invalid_authentication");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn static_token_mode_ignores_spoofed_principal_header() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let policy_path = temp_dir.path().join("policy.json");
+    let auth_path = temp_dir.path().join("auth.json");
+
+    std::fs::write(
+        &policy_path,
+        serde_json::to_string_pretty(&json!({
+            "principal_namespace_actions": [
+                {
+                    "principal": "operator",
+                    "namespace": "agent-demo",
+                    "actions": ["put", "get", "recall", "delete", "audit_read", "repair"]
+                }
+            ]
+        }))?,
+    )
+    .context("write policy file")?;
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "viewer-secret",
+                    "principal": "viewer"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let db_path = temp_dir.path().join("loong-memory.db");
+    let server = TestServer::spawn_with_security(temp_dir, db_path, Some(&policy_path), Some(&auth_path)).await?;
+
+    let response = server
+        .client
+        .post(server.url("/v1/memories"))
+        .header("authorization", "Bearer viewer-secret")
+        .header("x-loong-principal", "operator")
+        .json(&json!({
+            "namespace": "agent-demo",
+            "external_id": "profile",
+            "content": "Alice likes rust",
+            "metadata": {"source": "auth-test"}
+        }))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body: Value = response.json().await?;
+    assert_eq!(body["error"]["code"], "policy_denied");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn healthz_reports_static_token_auth_mode() -> Result<()> {
+    let temp_dir = TempDir::new().context("create temp dir")?;
+    let auth_path = temp_dir.path().join("auth.json");
+    std::fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": [
+                {
+                    "token": "operator-secret",
+                    "principal": "operator"
+                }
+            ]
+        }))?,
+    )
+    .context("write auth file")?;
+
+    let db_path = temp_dir.path().join("loong-memory.db");
+    let server = TestServer::spawn_with_security(temp_dir, db_path, None, Some(&auth_path)).await?;
+
+    let response = server.client.get(server.url("/healthz")).send().await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().await?;
+    assert_eq!(body["auth_mode"], "static_token");
     Ok(())
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,11 +100,15 @@ Phase 2 now starts with a minimal HTTP JSON daemon:
 
 Transport behavior:
 
-- protected routes require `x-loong-principal`
+- protected routes use one of two transport-auth modes:
+  - trusted-header mode: require `x-loong-principal`
+  - static-token mode: require `Authorization: Bearer <token>` and derive the
+    effective principal from the configured token mapping
 - request bodies map closely to existing engine request types
 - each request creates a fresh `MemoryEngine` against the configured SQLite path
 - synchronous SQLite/engine work is executed inside `tokio::task::spawn_blocking`
 - errors are mapped into structured HTTP JSON responses
+- `/healthz` reports both `policy_mode` and `auth_mode`
 
 This keeps the daemon thin. The control-plane rules still live in
 `MemoryEngine`, not in the transport handlers.
@@ -134,7 +138,10 @@ This keeps the daemon thin. The control-plane rules still live in
 - CLI can load a JSON `StaticPolicyConfig` via `--policy-file`; without it,
   the CLI preserves current local-operator ergonomics with `AllowAllPolicy`.
 - `loong-memoryd` can load the same JSON `StaticPolicyConfig`; protected routes
-  require `x-loong-principal` so transport requests carry an explicit principal.
+  preserve trusted-header mode by default, or switch to static bearer-token auth
+  via `--auth-file`.
+- In static-token mode, `loong-memoryd` derives the effective principal from the
+  bearer token mapping and ignores caller-supplied `x-loong-principal`.
 - Maintenance operations (`vector_health`, `vector_repair`) are executed through
   engine-level policy checks and audit events, not direct CLI store bypass.
 - Audit reads are namespace-scoped and require `Action::AuditRead`.
@@ -183,9 +190,10 @@ Current integration tests validate:
 - vector repair workflow (`dry-run` planning + transactional `apply`)
 - principal+namespace scoped static policy behavior
 - audit SQLite persistence/filter/limit/error behavior
-- daemon health, readiness failure, principal enforcement, malformed JSON,
-  validation failures, delete, recall, audit, vector health/repair, and deny
-  behavior over HTTP
+- daemon health/readiness behavior including `policy_mode` and `auth_mode`
+- daemon trusted-header enforcement and static bearer-token authentication
+- malformed JSON, validation failures, delete, recall, audit, vector
+  health/repair, deny behavior, and bearer-token spoof-resistance over HTTP
 
 Quality gates:
 

--- a/docs/examples/static-auth.example.json
+++ b/docs/examples/static-auth.example.json
@@ -1,0 +1,12 @@
+{
+  "tokens": [
+    {
+      "token": "operator-secret",
+      "principal": "operator"
+    },
+    {
+      "token": "viewer-secret",
+      "principal": "viewer"
+    }
+  ]
+}

--- a/docs/plans/2026-03-15-loong-memoryd-auth-envelope-design.md
+++ b/docs/plans/2026-03-15-loong-memoryd-auth-envelope-design.md
@@ -1,0 +1,274 @@
+# loong-memoryd Auth Envelope Design
+
+Date: 2026-03-15
+Owner: chumyin
+Issue: #8
+
+## 1. Context
+
+`loong-memoryd` now exposes a meaningful HTTP surface and already delegates
+authorization to the core `MemoryEngine`. Protected routes currently require:
+
+- `x-loong-principal`
+
+That gives the engine a principal string for policy evaluation, but it does not
+authenticate that principal. Any caller who can reach the daemon can claim any
+principal name.
+
+## 2. Problem Statement
+
+The daemon currently has authorization without real transport authentication.
+
+That is an important gap because the project now advertises an HTTP daemon as
+the Phase 2 runtime surface. Once a network boundary exists, "the client told us
+who they are" is no longer a sufficient identity model.
+
+The next high-value step is not OAuth or external identity integration. It is a
+minimal but real authentication envelope that proves which principal is being
+used for policy decisions.
+
+## 3. Goals
+
+1. Add an optional transport authentication mode for `loong-memoryd`.
+2. Authenticate callers with `Authorization: Bearer <token>` when auth mode is
+   enabled.
+3. Derive the effective principal from the configured token mapping rather than
+   trusting `x-loong-principal`.
+4. Preserve today's trusted-header mode when no auth config is supplied so
+   local operator ergonomics remain intact.
+5. Add end-to-end daemon tests for success, missing token, invalid token, and
+   spoofed principal-header rejection.
+6. Update docs so the daemon's authn/authz story matches shipped behavior.
+
+## 4. Non-Goals
+
+- OAuth/OIDC
+- external identity providers
+- token minting, rotation, or revocation APIs
+- dynamic auth reload
+- replacing or duplicating core policy logic
+- per-token authorization rules in the transport layer
+
+## 5. Approaches Considered
+
+### Approach A: Keep Trusted Header Mode Only
+
+Continue requiring `x-loong-principal` and document that the daemon is intended
+only for trusted local callers.
+
+Pros:
+
+- zero new config format
+- preserves the smallest possible daemon
+
+Cons:
+
+- does not actually improve transport authentication
+- weakens the credibility of the roadmap's authn/authz envelope claim
+- leaves principal spoofing trivial
+
+### Approach B: Optional Static Bearer Token Auth
+
+Add an optional auth file mapping static bearer tokens to principals. When the
+file is configured, protected routes require `Authorization: Bearer <token>` and
+the daemon derives principal from that mapping.
+
+Pros:
+
+- smallest real authentication step
+- simple to document and test
+- reuses the existing policy engine cleanly
+- preserves local trusted-header ergonomics when auth is not configured
+
+Cons:
+
+- static secret management only
+- no rotation or external identity integration
+
+### Approach C: Jump Straight to OAuth/OIDC or mTLS
+
+Integrate a fully externalized identity boundary immediately.
+
+Pros:
+
+- stronger long-term security model
+
+Cons:
+
+- far too much scope for the current repository phase
+- large dependency and operator-complexity jump
+- delays useful incremental hardening
+
+## 6. Chosen Approach
+
+Approach B.
+
+The repository needs a real authentication envelope now, not a complete
+enterprise identity system. Optional static bearer auth is the right
+middle-ground for this phase.
+
+## 7. Proposed Design
+
+## 7.1 Configuration Model
+
+Add an optional daemon CLI flag:
+
+- `--auth-file <path>`
+
+The auth file contains static token-to-principal mappings:
+
+```json
+{
+  "tokens": [
+    {
+      "token": "operator-secret",
+      "principal": "operator"
+    },
+    {
+      "token": "viewer-secret",
+      "principal": "viewer"
+    }
+  ]
+}
+```
+
+Validation requirements:
+
+- token must be non-empty
+- principal must be non-empty
+- duplicate tokens are rejected
+
+## 7.2 Runtime Modes
+
+The daemon should support two explicit auth modes:
+
+### Trusted Header Mode
+
+Used when `--auth-file` is absent.
+
+Behavior:
+
+- preserve today's `x-loong-principal` requirement
+- intended for local or otherwise trusted operator environments
+
+### Static Token Mode
+
+Used when `--auth-file` is present.
+
+Behavior:
+
+- protected routes require `Authorization: Bearer <token>`
+- bearer token maps to the effective principal
+- `x-loong-principal` is ignored for identity derivation
+
+This prevents callers from spoofing a more privileged principal in the header
+while using a token that belongs to a less privileged identity.
+
+## 7.3 Auth State
+
+Extend `ServiceState` with transport-auth configuration:
+
+- `auth_mode: AuthMode`
+
+Proposed enum:
+
+- `TrustedHeader`
+- `StaticToken { token_to_principal }`
+
+The token map should be immutable in runtime state.
+
+## 7.4 Health Response
+
+Extend `/healthz` with:
+
+- `auth_mode`
+
+Proposed values:
+
+- `trusted_header`
+- `static_token`
+
+This makes operational state visible without exposing secrets.
+
+## 7.5 Error Semantics
+
+When auth mode is `StaticToken`:
+
+- missing `Authorization` header -> `401`, `missing_authentication`
+- malformed `Authorization` value -> `401`, `invalid_authentication`
+- unknown token -> `401`, `invalid_authentication`
+
+When auth mode is `TrustedHeader`:
+
+- missing `x-loong-principal` -> existing `401`, `missing_principal`
+
+Health remains unauthenticated.
+
+## 7.6 Policy Interaction
+
+Transport authentication should only establish principal identity.
+Authorization remains unchanged:
+
+1. daemon authenticates request and derives principal
+2. daemon constructs `OperationContext`
+3. `MemoryEngine` enforces policy for that principal
+
+This keeps transport auth and core authorization cleanly separated.
+
+## 7.7 Test Strategy
+
+Add end-to-end tests for:
+
+- trusted-header mode still works when `--auth-file` is absent
+- static-token mode allows requests with valid bearer token
+- static-token mode rejects missing bearer token
+- static-token mode rejects invalid bearer token
+- static-token mode ignores spoofed `x-loong-principal`
+- `/healthz` reports `auth_mode`
+
+At least one spoofing test should prove that:
+
+- token maps to `viewer`
+- request sends `x-loong-principal: operator`
+- policy allows `operator` but not `viewer`
+- request is denied
+
+That is the most important regression test in the whole slice.
+
+## 7.8 Documentation Updates
+
+Update:
+
+- `README.md`
+- `docs/architecture.md`
+- `docs/research/phase2-service-evaluation-2026-03-15.md`
+
+The docs should describe:
+
+- trusted-header fallback mode
+- static bearer-token auth mode
+- principal derivation from bearer token
+- auth_mode visibility in health output
+
+## 8. Risks and Mitigations
+
+Risk: token auth creates a second policy system by accident.
+
+Mitigation:
+
+- auth config only maps token -> principal
+- all authorization stays inside the existing policy engine
+
+Risk: callers keep assuming `x-loong-principal` matters in token mode.
+
+Mitigation:
+
+- document that static-token mode ignores caller-supplied principal headers
+- add a regression test that proves spoofing does not work
+
+Risk: the daemon becomes harder to use locally.
+
+Mitigation:
+
+- preserve current trusted-header mode when `--auth-file` is absent
+- keep the new auth mode opt-in

--- a/docs/plans/2026-03-15-loong-memoryd-auth-envelope.md
+++ b/docs/plans/2026-03-15-loong-memoryd-auth-envelope.md
@@ -1,0 +1,195 @@
+# loong-memoryd Auth Envelope Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an optional static bearer-token authentication mode to `loong-memoryd` while preserving trusted-header behavior for local operator use.
+
+**Architecture:** Extend `ServiceConfig` and `ServiceState` with transport-auth configuration. Protected routes will authenticate using either the existing trusted-header mode or a new static-token mode that derives principal from `Authorization: Bearer <token>`, then continue routing authorization through the existing `MemoryEngine`.
+
+**Tech Stack:** Rust, `axum`, `tokio`, `serde`, existing `loong-memory-core`
+
+---
+
+### Task 1: Add failing daemon integration tests for static bearer auth
+
+**Files:**
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+
+- valid bearer token allows a protected request
+- missing bearer token returns `401`
+- invalid bearer token returns `401`
+- spoofed `x-loong-principal` is ignored in token mode
+- `/healthz` reports `auth_mode`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd bearer`
+Expected: FAIL because static-token auth mode does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Do not implement yet. This task establishes the red tests only.
+
+**Step 4: Run test to verify it passes**
+
+Not applicable in this task.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "test: add failing loong-memoryd auth envelope cases"
+```
+
+### Task 2: Add auth configuration types and trusted-header/static-token modes
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/src/main.rs`
+
+**Step 1: Write the failing test**
+
+Use the new tests from Task 1 for:
+
+- missing bearer token
+- invalid bearer token
+- `/healthz` auth mode reporting
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd missing_bearer`
+Run: `cargo test -p loong-memoryd invalid_bearer`
+Expected: FAIL because auth-file support and auth-mode selection do not exist.
+
+**Step 3: Write minimal implementation**
+
+- add `--auth-file` CLI support
+- add auth config structs and loader
+- add runtime `AuthMode`
+- extend health response with `auth_mode`
+- switch request authentication based on configured auth mode
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd healthz`
+Run: `cargo test -p loong-memoryd bearer`
+Expected: the mode-selection tests pass or progress substantially.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/src/main.rs
+git commit -m "feat: add loong-memoryd auth mode configuration"
+```
+
+### Task 3: Derive principal from bearer token and block spoofing
+
+**Files:**
+- Modify: `crates/loong-memoryd/src/lib.rs`
+- Modify: `crates/loong-memoryd/tests/http_service_integration.rs`
+
+**Step 1: Write the failing test**
+
+Use the new tests from Task 1 for:
+
+- valid bearer token request succeeds
+- spoofed `x-loong-principal` does not bypass policy
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loong-memoryd bearer_token_allows`
+Run: `cargo test -p loong-memoryd spoofed`
+Expected: FAIL until bearer principal derivation is fully wired.
+
+**Step 3: Write minimal implementation**
+
+- parse `Authorization: Bearer <token>`
+- look up token in the immutable token map
+- derive principal from the token mapping
+- ignore `x-loong-principal` in static-token mode
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd bearer`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/loong-memoryd/src/lib.rs crates/loong-memoryd/tests/http_service_integration.rs
+git commit -m "feat: derive loong-memoryd principal from bearer auth"
+```
+
+### Task 4: Update docs and research notes
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/research/phase2-service-evaluation-2026-03-15.md`
+
+**Step 1: Write the failing test**
+
+No product test for this task.
+
+**Step 2: Run test to verify it fails**
+
+Not applicable.
+
+**Step 3: Write minimal implementation**
+
+- document `--auth-file`
+- document static bearer-token mode and trusted-header fallback mode
+- update the research note with the stronger auth envelope and auth-related verification
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loong-memoryd`
+Expected: PASS with docs aligned to shipped behavior.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/architecture.md docs/research/phase2-service-evaluation-2026-03-15.md
+git commit -m "docs: describe loong-memoryd auth envelope"
+```
+
+### Task 5: Run full verification and prepare GitHub delivery
+
+**Files:**
+- No additional product files required
+
+**Step 1: Write the failing test**
+
+No new test.
+
+**Step 2: Run test to verify it fails**
+
+Not applicable.
+
+**Step 3: Write minimal implementation**
+
+- inspect `git status --short`
+- inspect `git diff --cached --name-only`
+- inspect `git diff --cached`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat: add loong-memoryd auth envelope"
+```

--- a/docs/research/phase2-service-evaluation-2026-03-15.md
+++ b/docs/research/phase2-service-evaluation-2026-03-15.md
@@ -3,8 +3,8 @@
 ## Summary
 
 This Phase 2 work now delivers both the initial daemon bootstrap and the first
-transport-hardening pass for `loong-memoryd`, the standalone HTTP JSON service
-that reuses the existing engine, policy, and audit contracts.
+transport-auth hardening pass for `loong-memoryd`, the standalone HTTP JSON
+service that reuses the existing engine, policy, and audit contracts.
 
 ## Why This Was the Right Next Step
 
@@ -33,11 +33,16 @@ Handlers delegate to `MemoryEngine` instead of re-implementing validation,
 policy, or audit logic. This keeps the transport layer small and preserves the
 repository's existing trust boundary.
 
-### 3. Explicit Principal Header
+### 3. Optional Static Bearer Auth Envelope
 
-Protected routes require `x-loong-principal`. This is intentionally minimal and
-maps directly onto the existing engine policy model without pretending to be a
-complete authentication solution.
+The daemon now supports two explicit transport-auth modes:
+
+- trusted-header mode when `--auth-file` is omitted
+- static-token mode when `--auth-file` is present
+
+Static-token mode requires `Authorization: Bearer <token>` and derives the
+effective principal from the configured token mapping instead of trusting
+caller-supplied `x-loong-principal`.
 
 ### 4. Per-Request Engine Construction
 
@@ -58,7 +63,7 @@ reactor.
 - `POST /v1/vector-health`
 - `POST /v1/vector-repair`
 - structured HTTP error mapping
-- startup config via `--db`, `--listen-addr`, `--policy-file`
+- startup config via `--db`, `--listen-addr`, `--policy-file`, `--auth-file`
 - service-level negative-path coverage for malformed JSON, validation failure,
   and readiness failure
 - updated repository docs
@@ -74,9 +79,14 @@ Local verification passed:
 Covered HTTP integration behaviors:
 
 - health endpoint does not require a principal
+- health endpoint reports both `policy_mode` and `auth_mode`
 - health endpoint reports readiness failure when the configured DB path cannot
   be opened
-- protected routes reject missing principal headers
+- trusted-header mode rejects missing principal headers
+- static-token mode accepts valid bearer tokens
+- static-token mode rejects missing bearer tokens
+- static-token mode rejects invalid bearer tokens
+- static-token mode ignores spoofed `x-loong-principal` headers
 - malformed JSON returns structured `invalid_json`
 - put/get roundtrip succeeds over the daemon surface
 - delete removes records over HTTP and preserves selector validation
@@ -94,12 +104,13 @@ This is a bootstrap slice, not the full Phase 2 end state. Still missing:
 - gRPC transport
 - SDK clients
 - metrics/tracing export
-- stronger transport authentication and policy reload
+- dynamic auth reload/rotation
+- stronger external identity integration (OIDC, mTLS, or equivalent)
 
 ## Outcome
 
 The repository now has a credible Phase 2 starting point: a real daemon
-boundary, transport-level identity propagation, structured health checks,
+boundary, a real transport authentication envelope, structured health checks,
 maintenance-route coverage, and end-to-end service tests for both happy and
 negative paths. That materially improves delivery completeness over a CLI-only
 Phase 1 story.


### PR DESCRIPTION
## Summary
- add optional static bearer-token authentication to loong-memoryd while preserving trusted-header mode when no auth file is configured
- derive principals from configured bearer tokens, report auth_mode from /healthz, and reject missing/invalid/spoofed transport identity inputs
- document the new auth envelope, add an example auth config, and cover startup validation plus end-to-end HTTP auth scenarios

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional static bearer-token authentication via --auth-file parameter with token-to-principal mapping
  * Two authentication modes: trusted-header (default) and static-token (when auth-file provided)
  * Health endpoint now reports active authentication mode

* **Documentation**
  * Updated quick start guide with bearer-token authentication examples
  * Added sample static authentication configuration template

<!-- end of auto-generated comment: release notes by coderabbit.ai -->